### PR TITLE
QBDIPreload: Give argc and argv at the qbdipreload_on_start callback

### DIFF
--- a/tools/QBDIPreload/include/QBDIPreload.h
+++ b/tools/QBDIPreload/include/QBDIPreload.h
@@ -88,9 +88,11 @@ QBDI_EXPORT int qbdipreload_hook_main(void *main);
  * It provides the main function address, that can be used
  * to place a hook using the `qbdipreload_hook_main` API.
  * @param[in]   main    Address of the main function
+ * @param[in]   argc    Number of arguments of the main function
+ * @param[in]   argv    Arguments of the main function
  * @return      int     QBDIPreload state
  */
-extern int qbdipreload_on_start(void *main);
+extern int qbdipreload_on_start(void *main, int argc, char **argv);
 
 /*! Function called when preload hook on main function is triggered.
  * It provides original (and platforms dependent) GPR and FPR contexts.

--- a/tools/QBDIPreload/src/linux_preload.c
+++ b/tools/QBDIPreload/src/linux_preload.c
@@ -282,7 +282,7 @@ QBDI_EXPORT int __libc_start_main(int (*main) (int, char**, char**), int argc, c
 
     o_libc_start_main = (start_main_fn) dlsym(RTLD_NEXT, "__libc_start_main");
 
-    int status = qbdipreload_on_start(main);
+    int status = qbdipreload_on_start(main, argc, ubp_av);
     if (status == QBDIPRELOAD_NOT_HANDLED) {
         status = qbdipreload_hook_main(main);
     }

--- a/tools/validator/linux_validator.cpp
+++ b/tools/validator/linux_validator.cpp
@@ -97,7 +97,7 @@ int QBDI::qbdipreload_on_exit(int status) {
     return QBDIPRELOAD_NO_ERROR;
 }
 
-int QBDI::qbdipreload_on_start(void *main) {
+int QBDI::qbdipreload_on_start(void *main, int argc, char **argv) {
     pid_t debugged, instrumented;
     LinuxProcess* debuggedProcess = nullptr;
 


### PR DESCRIPTION
In some cases, it's useful to provide `argc` and `argv` (of the instrumented binary) to the *qbditool*.