### PR TITLE
Fix setGPRState and setFPRState not working in callbacks

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -162,12 +162,12 @@ FPRState* Engine::getFPRState() const {
 
 void Engine::setGPRState(GPRState* gprState) {
     RequireAction("Engine::setGPRState", gprState, return);
-    *(this->gprState) = *gprState;
+    *(this->curGPRState) = *gprState;
 }
 
 void Engine::setFPRState(FPRState* fprState) {
     RequireAction("Engine::setFPRState", fprState, return);
-    *(this->fprState) = *fprState;
+    *(this->curFPRState) = *fprState;
 }
 
 bool Engine::isPreInst() const {


### PR DESCRIPTION
A stupid change that was not properly propagated.
Fix #8 