### PR TITLE
Revising simulateCall and Call API to include more C++ and bindings friendly prototypes

### DIFF
--- a/cmake/stub.cpp
+++ b/cmake/stub.cpp
@@ -35,6 +35,7 @@ FORCE_EXPORT_C(removeAllInstrumentedRanges)
 FORCE_EXPORT_C(run)
 FORCE_EXPORT_C(call)
 FORCE_EXPORT_C(callV)
+FORCE_EXPORT_C(callA)
 FORCE_EXPORT_C(getGPRState)
 FORCE_EXPORT_C(getFPRState)
 FORCE_EXPORT_C(setGPRState)
@@ -58,17 +59,18 @@ FORCE_EXPORT_C(clearCache)
 FORCE_EXPORT_C(clearAllCache)
 
 // Logs
-FORCE_EXPORT(setLogOutput)
-FORCE_EXPORT(addLogFilter)
+FORCE_EXPORT_C(setLogOutput)
+FORCE_EXPORT_C(addLogFilter)
 
 // Memory
 FORCE_EXPORT(getCurrentProcessMaps)
 FORCE_EXPORT(getRemoteProcessMaps)
-FORCE_EXPORT(alignedAlloc)
-FORCE_EXPORT(alignedFree)
-FORCE_EXPORT(allocateVirtualStack)
-FORCE_EXPORT(simulateCall)
-FORCE_EXPORT(simulateCallV)
+FORCE_EXPORT_C(alignedAlloc)
+FORCE_EXPORT_C(alignedFree)
+FORCE_EXPORT_C(allocateVirtualStack)
+FORCE_EXPORT_C(simulateCall)
+FORCE_EXPORT_C(simulateCallV)
+FORCE_EXPORT_C(simulateCallA)
 static const void* dummy__getModuleNames1 _QBDI_FORCE_USE = (const void*) (std::vector<std::string> (*)())&(QBDI::getModuleNames);
 static const void* dummy__getModuleNames2 _QBDI_FORCE_USE = (const void*) (char** (*)(size_t*))&(QBDI::getModuleNames);
 

--- a/examples/cryptolock.cpp
+++ b/examples/cryptolock.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     // Setup initial GPR state, this fakestack will produce a ret FAKE_RET_ADDR at the end of the execution
     // Also setup one argument on the stack which is the password string
     QBDI::allocateVirtualStack(state, STACK_SIZE, &fakestack);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, argv[1]);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) argv[1]});
 
     std::cout << "Running cryptolock(\"" << argv[1] <<"\")" << std::endl;
     vm->run((QBDI::rword) cryptolock, (QBDI::rword) FAKE_RET_ADDR);

--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
     if(n < 1) {
         n = 1;
     }
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, (QBDI::rword) n);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) n});
 
     std::cout << "Running fibonacci(" << n << ") ..." << std::endl;
     // Instrument everything

--- a/examples/mnemonicFilter.cpp
+++ b/examples/mnemonicFilter.cpp
@@ -48,7 +48,7 @@ int main(int argc, char ** argv)
     // Add our binary to the instrumented range
     vm->addInstrumentedModuleFromAddr((QBDI::rword) &HW);
     // Call the hello world function
-    QBDI::simulateCall(state, 0x0, 0);
+    QBDI::simulateCall(state, 0x0);
     vm->run((QBDI::rword) HW, (QBDI::rword) 0x0);
 
     delete vm;

--- a/examples/thedude.cpp
+++ b/examples/thedude.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     state = vm->getGPRState();
     // Setup initial GPR state, this fakestack will produce a ret NULL at the end of the execution
     QBDI::allocateVirtualStack(state, STACK_SIZE, &fakestack);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 0);
+    QBDI::simulateCall(state, FAKE_RET_ADDR);
 
     std::cout << "Running thedude() with trace level " << traceLevel << "..." << std::endl;
     // Select which part to instrument

--- a/include/QBDI/Memory.h
+++ b/include/QBDI/Memory.h
@@ -143,10 +143,20 @@ QBDI_EXPORT void qbdi_simulateCall(GPRState *ctx, rword returnAddress, uint32_t 
  *  @param[in] ctx           GPRState where the simulated call will be setup. The state needs to 
  *                           point to a valid stack for example setup with allocateVirtualStack().
  *  @param[in] returnAddress Return address of the call to simulate.
- *  @param[in] argNum        The number of arguments in the variadic list.
+ *  @param[in] argNum        The number of arguments in the va_list object.
  *  @param[in] ap            An stdarg va_list object.
  */
 QBDI_EXPORT void qbdi_simulateCallV(GPRState *ctx, rword returnAddress, uint32_t argNum, va_list ap);
+
+/*! Simulate a call by modifying the stack and registers accordingly (C array version).
+ *
+ *  @param[in] ctx           GPRState where the simulated call will be setup. The state needs to 
+ *                           point to a valid stack for example setup with allocateVirtualStack().
+ *  @param[in] returnAddress Return address of the call to simulate.
+ *  @param[in] argNum        The number of arguments in the array args.
+ *  @param[in] args          An array or arguments.
+ */
+QBDI_EXPORT void qbdi_simulateCallA(GPRState *ctx, rword returnAddress, uint32_t argNum, const rword* args);
 
 #ifdef __cplusplus
 /*
@@ -201,20 +211,15 @@ inline bool allocateVirtualStack(GPRState *ctx, uint32_t stackSize, uint8_t **st
     return qbdi_allocateVirtualStack(ctx, stackSize, stack);
 }
 
-/*! Simulate a call by modifying the stack and registers accordingly.
+/*! Simulate a call by modifying the stack and registers accordingly (std::vector version).
  *
  *  @param[in] ctx           GPRState where the simulated call will be setup. The state needs to 
  *                           point to a valid stack for example setup with allocateVirtualStack().
  *  @param[in] returnAddress Return address of the call to simulate.
- *  @param[in] argNum        The number of arguments in the variadic list.
- *  @param[in] ...           A variadic list of arguments.
+ *  @param[in] args          A list of arguments.
  */
-inline void simulateCall(GPRState *ctx, rword returnAddress, uint32_t argNum, ...) {
-    va_list  ap;
-    // Handle the arguments
-    va_start(ap, argNum);
-    qbdi_simulateCallV(ctx, returnAddress, argNum, ap);
-    va_end(ap);
+inline void simulateCall(GPRState *ctx, rword returnAddress, const std::vector<rword>& args = {}) {
+    qbdi_simulateCallA(ctx, returnAddress, args.size(), args.data());
 }
 
 /*! Simulate a call by modifying the stack and registers accordingly (stdarg version).
@@ -222,12 +227,25 @@ inline void simulateCall(GPRState *ctx, rword returnAddress, uint32_t argNum, ..
  *  @param[in] ctx           GPRState where the simulated call will be setup. The state needs to 
  *                           point to a valid stack for example setup with allocateVirtualStack().
  *  @param[in] returnAddress Return address of the call to simulate.
- *  @param[in] argNum        The number of arguments in the variadic list.
+ *  @param[in] argNum        The number of arguments in the va_list object.
  *  @param[in] ap            An stdarg va_list object.
  */
 inline void simulateCallV(GPRState *ctx, rword returnAddress, uint32_t argNum, va_list ap) {
-    return qbdi_simulateCallV(ctx, returnAddress, argNum, ap);
+    qbdi_simulateCallV(ctx, returnAddress, argNum, ap);
 }
+
+/*! Simulate a call by modifying the stack and registers accordingly (C array version).
+ *
+ *  @param[in] ctx           GPRState where the simulated call will be setup. The state needs to 
+ *                           point to a valid stack for example setup with allocateVirtualStack().
+ *  @param[in] returnAddress Return address of the call to simulate.
+ *  @param[in] argNum        The number of arguments in the array args.
+ *  @param[in] args          An array or arguments.
+ */
+inline void simulateCallA(GPRState *ctx, rword returnAddress, uint32_t argNum, const rword* args) {
+    qbdi_simulateCallA(ctx, returnAddress, argNum, args);
+}
+
 
 }
 }

--- a/include/QBDI/VM.h
+++ b/include/QBDI/VM.h
@@ -152,8 +152,7 @@ class QBDI_EXPORT VM {
      *
      * @param[in] [retval]   Pointer to the returned value (optional).
      * @param[in] function   Address of the function start instruction.
-     * @param[in] argNum     The number of arguments in the variadic list.
-     * @param[in] ...        A variadic list of arguments.
+     * @param[in] args       A list of arguments.
      *
      * @return  True if at least one block has been executed.
      *
@@ -166,10 +165,21 @@ class QBDI_EXPORT VM {
      *     QBDI::allocateVirtualStack(state, 0x1000000, &fakestack);
      *     vm->addInstrumentedModuleFromAddr(funcPtr);
      *     rword retVal;
-     *     vm->call(&retVal, funcPtr, 1, 42);
+     *     vm->call(&retVal, funcPtr, {42});
      *
      */
-    bool        call(rword* retval, rword function, uint32_t argNum, ...);
+    bool        call(rword* retval, rword function, const std::vector<rword>& args = {});
+
+    /*! Call a function using the DBI (and its current state).
+     *
+     * @param[in] [retval]   Pointer to the returned value (optional).
+     * @param[in] function   Address of the function start instruction.
+     * @param[in] argNum     The number of arguments in the array of arguments.
+     * @param[in] args       An array of arguments.
+     *
+     * @return  True if at least one block has been executed.
+     */
+    bool        callA(rword* retval, rword function, uint32_t argNum, const rword* args);
 
     /*! Call a function using the DBI (and its current state).
      *

--- a/include/QBDI/VM_C.h
+++ b/include/QBDI/VM_C.h
@@ -164,6 +164,18 @@ QBDI_EXPORT bool qbdi_call(VMInstanceRef instance, rword* retval, rword function
  */
 QBDI_EXPORT bool qbdi_callV(VMInstanceRef instance, rword* retval, rword function, uint32_t argNum, va_list ap);
 
+/*! Call a function using the DBI (and its current state).
+ *
+ * @param[in] instance   VM instance.
+ * @param[in] [retval]   Pointer to the returned value (optional).
+ * @param[in] function   Address of the function start instruction.
+ * @param[in] argNum     The number of arguments in the variadic list.
+ * @param[in] ap         An stdarg va_list object.
+ *
+ * @return  True if at least one block has been executed.
+ */
+QBDI_EXPORT bool qbdi_callA(VMInstanceRef instance, rword* retval, rword function, uint32_t argNum, const rword* args);
+
 /*! Obtain the current general purpose register state.
  *
  * @param[in] instance  VM instance.

--- a/src/Engine/VM_C.cpp
+++ b/src/Engine/VM_C.cpp
@@ -108,6 +108,11 @@ bool qbdi_callV(VMInstanceRef instance, rword* retval, rword function, uint32_t 
     return ((VM*) instance)->callV(retval, function, argNum, ap);
 }
 
+bool qbdi_callA(VMInstanceRef instance, rword* retval, rword function, uint32_t argNum, const rword* args) {
+    RequireAction("VM_C::callA", instance, return false);
+    return ((VM*) instance)->callA(retval, function, argNum, args);
+}
+
 GPRState* qbdi_getGPRState(VMInstanceRef instance) {
     RequireAction("VM_C::getGPRState", instance, return nullptr);
     return ((VM*) instance)->getGPRState();

--- a/test/API/MemoryAccessTest.cpp
+++ b/test/API/MemoryAccessTest.cpp
@@ -351,7 +351,7 @@ TEST_F(MemoryAccessTest, DISABLED_Read8) {
     
     vm->addMemAccessCB(QBDI::MEMORY_READ, checkArrayRead8, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayRead8, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -371,7 +371,7 @@ TEST_F(MemoryAccessTest, DISABLED_Read16) {
     
     vm->addMemAccessCB(QBDI::MEMORY_READ, checkArrayRead16, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayRead16, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -391,7 +391,7 @@ TEST_F(MemoryAccessTest, DISABLED_Read32) {
     
     vm->addMemAccessCB(QBDI::MEMORY_READ, checkArrayRead32, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayRead32, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -411,7 +411,7 @@ TEST_F(MemoryAccessTest, DISABLED_Write8) {
     
     vm->addMemAccessCB(QBDI::MEMORY_WRITE, checkArrayWrite8, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayWrite8, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -431,7 +431,7 @@ TEST_F(MemoryAccessTest, DISABLED_Write16) {
     
     vm->addMemAccessCB(QBDI::MEMORY_WRITE, checkArrayWrite16, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayWrite16, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -451,7 +451,7 @@ TEST_F(MemoryAccessTest, DISABLED_Write32) {
     
     vm->addMemAccessCB(QBDI::MEMORY_WRITE, checkArrayWrite32, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayWrite32, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -472,7 +472,7 @@ TEST_F(MemoryAccessTest, DISABLED_BasicBlockRead) {
     vm->recordMemoryAccess(QBDI::MEMORY_READ);
     vm->addVMEventCB(QBDI::VMEvent::BASIC_BLOCK_EXIT, checkUnrolledRead, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, buffer);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer});
     bool ran = vm->run((QBDI::rword) unrolledRead, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -493,7 +493,7 @@ TEST_F(MemoryAccessTest, DISABLED_BasicBlockWrite) {
     vm->recordMemoryAccess(QBDI::MEMORY_WRITE);
     vm->addVMEventCB(QBDI::VMEvent::BASIC_BLOCK_EXIT, checkUnrolledWrite, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, buffer);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer});
     bool ran = vm->run((QBDI::rword) unrolledWrite, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -513,7 +513,7 @@ TEST_F(MemoryAccessTest, DISABLED_ReadRange) {
     
     vm->addMemRangeCB((QBDI::rword) buffer, (QBDI::rword) (buffer + buffer_size), QBDI::MEMORY_READ, checkArrayRead32, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayRead32, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -533,7 +533,7 @@ TEST_F(MemoryAccessTest, DISABLED_WriteRange) {
     
     vm->addMemRangeCB((QBDI::rword) buffer, (QBDI::rword) (buffer + buffer_size), QBDI::MEMORY_WRITE, checkArrayWrite32, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayWrite32, (QBDI::rword) FAKE_RET_ADDR);
 
     ASSERT_EQ(true, ran);
@@ -553,7 +553,7 @@ TEST_F(MemoryAccessTest, DISABLED_ReadWriteRange) {
 
     // Array write
     uint32_t cb1 = vm->addMemRangeCB((QBDI::rword) buffer, (QBDI::rword) (buffer + buffer_size), QBDI::MEMORY_READ_WRITE, checkArrayWrite32, &info);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     bool ran = vm->run((QBDI::rword) arrayWrite32, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_EQ(true, ran);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -564,7 +564,7 @@ TEST_F(MemoryAccessTest, DISABLED_ReadWriteRange) {
     info.i = 0;
     vm->deleteInstrumentation(cb1);
     vm->addMemRangeCB((QBDI::rword) buffer, (QBDI::rword) (buffer + buffer_size), QBDI::MEMORY_READ_WRITE, checkArrayRead32, &info);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 2, buffer, buffer_size);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) buffer, (QBDI::rword) buffer_size});
     ran = vm->run((QBDI::rword) arrayRead32, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_EQ(true, ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -584,21 +584,21 @@ TEST_F(MemoryAccessTest, DISABLED_MemorySnooping) {
     // Will replace a with 0x42 on read,  Will replace c with 0x42 on write
     uint32_t snoop1 = vm->addMemAddrCB((QBDI::rword) &a, QBDI::MEMORY_READ, readSnooper, &a);
     uint32_t snoop2 = vm->addMemAddrCB((QBDI::rword) &c, QBDI::MEMORY_WRITE, writeSnooper, &c);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 3, &a, &b, &c);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) &a, (QBDI::rword) &b, (QBDI::rword) &c});
     a = 10, b = 42, c = 1337;
     vm->run((QBDI::rword) mad, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
     ASSERT_EQ((QBDI::rword) 0x42, ret);
     // Will replace b with 0x42 on read, no effect because snoop2 is still active
     uint32_t snoop3 = vm->addMemAddrCB((QBDI::rword) &b, QBDI::MEMORY_READ, readSnooper, &b);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 3, &a, &b, &c);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) &a, (QBDI::rword) &b, (QBDI::rword) &c});
     a = 10, b = 42, c = 1337;
     vm->run((QBDI::rword) mad, (QBDI::rword) FAKE_RET_ADDR);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
     ASSERT_EQ((QBDI::rword) 0x42, ret);
     // Deleting snoop2, effect of snoop1 and snoop3
     vm->deleteInstrumentation(snoop2);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 3, &a, &b, &c);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) &a, (QBDI::rword) &b, (QBDI::rword) &c});
     a = 10, b = 42, c = 1337;
     vm->run((QBDI::rword) mad, (QBDI::rword) FAKE_RET_ADDR);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -606,7 +606,7 @@ TEST_F(MemoryAccessTest, DISABLED_MemorySnooping) {
     ASSERT_EQ(mad(&a, &b, &c), ret);
     // Deleting snoop1, effect of snoop3
     vm->deleteInstrumentation(snoop1);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 3, &a, &b, &c);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) &a, (QBDI::rword) &b, (QBDI::rword) &c});
     a = 10, b = 42, c = 1337;
     vm->run((QBDI::rword) mad, (QBDI::rword) FAKE_RET_ADDR);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -614,7 +614,7 @@ TEST_F(MemoryAccessTest, DISABLED_MemorySnooping) {
     ASSERT_EQ(mad(&a, &b, &c), ret);
     // Deleting snoop3
     vm->deleteInstrumentation(snoop3);
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 3, &a, &b, &c);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {(QBDI::rword) &a, (QBDI::rword) &b, (QBDI::rword) &c});
     a = 10, b = 42, c = 1337;
     vm->run((QBDI::rword) mad, (QBDI::rword) FAKE_RET_ADDR);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);

--- a/test/API/VMTest.cpp
+++ b/test/API/VMTest.cpp
@@ -123,7 +123,7 @@ void VMTest::TearDown() {
 
 
 TEST_F(VMTest, Call0) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 0);
+    QBDI::simulateCall(state, FAKE_RET_ADDR);
 
     vm->run((QBDI::rword) dummyFun0, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -134,7 +134,7 @@ TEST_F(VMTest, Call0) {
 
 
 TEST_F(VMTest, Call1) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, 42);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {42});
 
     vm->run((QBDI::rword) dummyFun1, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -145,7 +145,7 @@ TEST_F(VMTest, Call1) {
 
 
 TEST_F(VMTest, Call4) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 4, 1, 2, 3, 5);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 5});
 
     vm->run((QBDI::rword) dummyFun4, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -156,7 +156,7 @@ TEST_F(VMTest, Call4) {
 
 
 TEST_F(VMTest, Call5) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 5, 1, 2, 3, 5, 8);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 5, 8});
 
     vm->run((QBDI::rword) dummyFun5, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -166,7 +166,7 @@ TEST_F(VMTest, Call5) {
 }
 
 TEST_F(VMTest, Call8) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 8, 1, 2, 3, 5, 8, 13, 21, 34);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 5, 8, 13, 21, 34});
 
     vm->run((QBDI::rword) dummyFun8, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -177,7 +177,7 @@ TEST_F(VMTest, Call8) {
 
 
 TEST_F(VMTest, ExternalCall) {
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, 42);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {42});
 
     vm->run((QBDI::rword) dummyFunCall, (QBDI::rword) FAKE_RET_ADDR);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -210,7 +210,7 @@ QBDI::VMAction evilCbk(QBDI::VMInstanceRef vm, QBDI::GPRState *gprState, QBDI::F
 
 TEST_F(VMTest, InstCallback) {
     QBDI::rword info[2] = {42, 0};
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, info[0]);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {info[0]});
 
     QBDI::rword rstart = (QBDI::rword) &satanicFun;
     QBDI::rword rend = (QBDI::rword) (((uint8_t*) &satanicFun) + 100);
@@ -315,7 +315,7 @@ TEST_F(VMTest, MnemCallback) {
                                          QBDI::InstPosition::PREINST,
                                          evilMnemCbk, &info);
 
-    bool ran = vm->call(&retval, (QBDI::rword) satanicFun, 1, info[0]);
+    bool ran = vm->call(&retval, (QBDI::rword) satanicFun, {info[0]});
     ASSERT_TRUE(ran);
 
     EXPECT_EQ(retval, (QBDI::rword) satanicFun(info[0]));
@@ -369,7 +369,7 @@ QBDI::VMAction checkTransfer(QBDI::VMInstanceRef vm, const QBDI::VMState *state,
 
 TEST_F(VMTest, VMEvent_ExecTransfer) {
     int s = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 1, 42);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {42});
     bool instrumented = vm->addInstrumentedModuleFromAddr((QBDI::rword)&dummyFunCall);
     ASSERT_TRUE(instrumented);
     uint32_t id = vm->addVMEventCB(QBDI::VMEvent::EXEC_TRANSFER_CALL, checkTransfer, (void*) &s);
@@ -399,7 +399,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 4, 1, 2, 3, 4);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4});
     bool ran = vm->run((QBDI::rword) dummyFun4, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -412,7 +412,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 5, 1, 2, 3, 4, 5);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4, 5});
     ran = vm->run((QBDI::rword) dummyFun5, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -424,7 +424,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 4, 1, 2, 3, 4);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4});
     ran = vm->run((QBDI::rword) dummyFun4, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -434,7 +434,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 5, 1, 2, 3, 4, 5);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4, 5});
     ran = vm->run((QBDI::rword) dummyFun5, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -446,7 +446,7 @@ TEST_F(VMTest, CacheInvalidation) {
     
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 5, 1, 2, 3, 4, 5);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4, 5});
     ran = vm->run((QBDI::rword) dummyFun5, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -458,7 +458,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 4, 1, 2, 3, 4);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4});
     ran = vm->run((QBDI::rword) dummyFun4, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -468,7 +468,7 @@ TEST_F(VMTest, CacheInvalidation) {
 
     count1 = 0;
     count2 = 0;
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 5, 1, 2, 3, 4, 5);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4, 5});
     ran = vm->run((QBDI::rword) dummyFun5, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);
@@ -521,7 +521,7 @@ TEST_F(VMTest, DelayedCacheFlush) {
     info.instID = vm->addCodeRangeCB((QBDI::rword) dummyFun4, ((QBDI::rword) dummyFun4) + 10, 
                                     QBDI::InstPosition::POSTINST, funkyCountInstruction, &info);
 
-    QBDI::simulateCall(state, FAKE_RET_ADDR, 4, 1, 2, 3, 4);
+    QBDI::simulateCall(state, FAKE_RET_ADDR, {1, 2, 3, 4});
     bool ran = vm->run((QBDI::rword) dummyFun4, (QBDI::rword) FAKE_RET_ADDR);
     ASSERT_TRUE(ran);
     QBDI::rword ret = QBDI_GPR_GET(state, QBDI::REG_RETURN);


### PR DESCRIPTION
Should fix #9 .

The idea is to have ``call`` and ``simulateCall`` use variadic arguments in C but std::vectors in C++.
All the implementation use the underlying ``A`` version which relies on C array.

@JonathanSalwan Does the C++ version works for you?

Now having written that I wonder about the relevance of the ``V`` versions which use va_list object.

@nezetic Should we keep the ``V``version?