### PR TITLE
Create Ubuntu docker image without build dependencies

### DIFF
--- a/package/ubuntu_latest_docker_packager/Dockerfile
+++ b/package/ubuntu_latest_docker_packager/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:17.10
-MAINTAINER Charles Hubain <chubain@quarkslab.com>
+ARG UBUNTU_TAG=latest
+
+# Packager image
+FROM ubuntu:$UBUNTU_TAG as builder
 
 ARG QBDI_BUILD_TYPE=Release
 
@@ -73,12 +75,25 @@ RUN sudo chown -R $USER:$USER . && \
     ln -s $HOME/qbdi-deps/deps deps && \
     mkdir build && \
     cd build && \
-    cmake -DCMAKE_BUILD_TYPE=$QBDI_BUILD_TYPE -DCMAKE_CROSSCOMPILING=FALSE -DPLATFORM=$QBDI_PLATFORM -DCMAKE_INSTALL_PREFIX=$PREFIX ../ && \
+    cmake -DCMAKE_BUILD_TYPE=$QBDI_BUILD_TYPE \
+          -DCMAKE_CROSSCOMPILING=FALSE \
+          -DPLATFORM=$QBDI_PLATFORM \
+          -DCMAKE_INSTALL_PREFIX=$PREFIX .. && \
     make -j2 && \
     ./test/QBDITest && \
-    rm -f QBDI-*-$QBDI_PLATFORM.deb && \
-    cpack -G DEB && \
-    sudo dpkg -i QBDI-*-$QBDI_PLATFORM.deb
+    cpack -G DEB
 
-WORKDIR "$HOME/"
+# Target image
+FROM ubuntu:$UBUNTU_TAG
+MAINTAINER Charles Hubain <chubain@quarkslab.com>
+
+ENV USER docker
+ENV HOME /home/$USER
+ENV QBDI_PLATFORM linux-X86_64
+
+WORKDIR /root
+COPY --from=builder $HOME/qbdi/build/*.deb .
+RUN apt-get update && \
+    apt-get install -y ./*.deb
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This patch introduces a multi-stage build for the docker image based on `ubuntu:latest`. The final image will both contain the DEB package and have it installed. After this change, all the build dependencies will be removed and the final image will be considerably smaller (1 GB -> 500 MB), but still be able to run QBDI. To reduce the size of the image even more, see #55.

This change should be completely compatible with the existing scripts. The only important change is the use of the `latest` tag for the Ubuntu image instead of the `17.10` tag. The build on the new version has been tested and works as expected.