### PR TITLE
Improve Validator and Minor Fix

### DIFF
--- a/src/ExecBlock/ExecBlock.cpp
+++ b/src/ExecBlock/ExecBlock.cpp
@@ -231,7 +231,7 @@ SeqWriteResult ExecBlock::writeSequence(std::vector<Patch>::const_iterator seqIt
     }
 
     // Check if there's enough space left
-    if(getEpilogueOffset() < MINIMAL_BLOCK_SIZE) {
+    if(getEpilogueOffset() <= MINIMAL_BLOCK_SIZE) {
         LogDebug("ExecBlock::writeBasicBlock", "ExecBlock %p is full", this);
         return {EXEC_BLOCK_FULL, 0, 0};
     }
@@ -333,10 +333,10 @@ void ExecBlock::makeRX() {
 }
 
 void ExecBlock::makeRW() {
-    LogDebug("ExecBlock::makeRX", "Making ExecBlock %p RW", this);
+    LogDebug("ExecBlock::makeRW", "Making ExecBlock %p RW", this);
     if(pageState != RW) {
         RequireAction(
-            "ExecBlock::makeRX",
+            "ExecBlock::makeRW",
             !llvm::sys::Memory::protectMappedMemory(codeBlock, PF::MF_READ | PF::MF_WRITE),
             abort()
         );

--- a/templates/qbdi_preload_template/qbdi_preload_template.c
+++ b/templates/qbdi_preload_template/qbdi_preload_template.c
@@ -28,6 +28,7 @@ int qbdipreload_on_premain(void *gprCtx, void *fpuCtx) {
 
 
 int qbdipreload_on_main(int argc, char** argv) {
+    qbdi_addLogFilter("*", QBDI_DEBUG);
     return QBDIPRELOAD_NOT_HANDLED;
 }
 

--- a/tools/QBDIPreload/src/darwin_preload.c
+++ b/tools/QBDIPreload/src/darwin_preload.c
@@ -225,9 +225,6 @@ void catchEntrypoint(int argc, char **argv) {
     status = qbdipreload_on_main(argc, argv);
 
     if (DEFAULT_HANDLER && (status == QBDIPRELOAD_NOT_HANDLED)) {
-#if defined(_QBDI_DEBUG)
-        qbdi_addLogFilter("*", QBDI_DEBUG);
-#endif
         VMInstanceRef vm;
         qbdi_initVM(&vm, NULL, NULL);
         qbdi_instrumentAllExecutableMaps(vm);

--- a/tools/QBDIPreload/src/linux_preload.c
+++ b/tools/QBDIPreload/src/linux_preload.c
@@ -162,9 +162,6 @@ void catchEntrypoint(int argc, char** argv) {
     status = qbdipreload_on_main(argc, argv);
 
     if (DEFAULT_HANDLER && (status == QBDIPRELOAD_NOT_HANDLED)) {
-#if defined(_QBDI_DEBUG)
-        qbdi_addLogFilter("*", QBDI_DEBUG);
-#endif
         VMInstanceRef vm;
         qbdi_initVM(&vm, NULL, NULL);
         qbdi_instrumentAllExecutableMaps(vm);

--- a/tools/validation_runner/RunConfig.py
+++ b/tools/validation_runner/RunConfig.py
@@ -38,7 +38,7 @@ class TestConfig:
         self.command = d['command']
         self.arguments = list(d['arguments'].lstrip("['").rstrip("']").split("', '"))
         return self
-        
+
     def command_line(self):
         return '{} {}'.format(self.command, ' '.join(self.arguments))
 

--- a/tools/validation_runner/RunResult.py
+++ b/tools/validation_runner/RunResult.py
@@ -130,15 +130,21 @@ class RunResult:
 
         if regression == 0:
             print('[+] No regression')
-        else: 
+        else:
             print('[+] ERROR: {} regressions encountered'.format(regression))
         return regression
-                    
-            
+
+
     def get_branch_commit(self):
-        out = subprocess.check_output(['git', 'status', '-b', '-uno', '--porcelain=2'], universal_newlines=True)
-        self.commit = scan_for_pattern(out, '# branch.oid ([0-9a-fA-F]+)')[0]
-        self.branch = scan_for_pattern(out, '# branch.head (\S+)')[0]
+        try:
+            out = subprocess.check_output(['git', 'status', '-b', '-uno', '--porcelain=2'], universal_newlines=True)
+        except Exception as e:
+            print('[!] git command error : {}'.format(e))
+            self.commit = 'UNKNOWN'
+            self.branch = 'UNKNOWN'
+        else:
+            self.commit = scan_for_pattern(out, '# branch.oid ([0-9a-fA-F]+)')[0]
+            self.branch = scan_for_pattern(out, '# branch.head (\S+)')[0]
 
     def write_to_db(self, db):
         run_id = db.insert_run_result(self)

--- a/tools/validation_runner/SQLite.py
+++ b/tools/validation_runner/SQLite.py
@@ -30,8 +30,8 @@ class SQLiteDBAdapter:
     def setup_db(self):
         cursor = self.connection.cursor()
         cursor.execute('''CREATE TABLE IF NOT EXISTS Runs (
-                            run_id INTEGER PRIMARY KEY AUTOINCREMENT, 
-                            branch TEXT, 
+                            run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            branch TEXT,
                             "commit" TEXT,
                             timestamp INTEGER,
                             total_tests INTEGER,
@@ -48,7 +48,7 @@ class SQLiteDBAdapter:
                             critical_casc INTEGER,
                             coverage_log TEXT);''')
         cursor.execute('''CREATE TABLE IF NOT EXISTS Tests (
-                            test_id INTEGER PRIMARY KEY AUTOINCREMENT, 
+                            test_id INTEGER PRIMARY KEY AUTOINCREMENT,
                             run_id INTEGER,
                             command TEXT,
                             arguments TEXT,
@@ -72,10 +72,10 @@ class SQLiteDBAdapter:
 
     def insert_run_result(self, run_result):
         cursor = self.connection.cursor()
-        cursor.execute('''INSERT INTO Runs (branch, "commit", timestamp, total_tests, passed_tests, 
-                          total_instr, unique_instr, errors, no_impact_err, non_critical_err, 
-                          critical_err, cascades, no_impact_casc, non_critical_casc, critical_casc, 
-                          coverage_log) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);''', 
+        cursor.execute('''INSERT INTO Runs (branch, "commit", timestamp, total_tests, passed_tests,
+                          total_instr, unique_instr, errors, no_impact_err, non_critical_err,
+                          critical_err, cascades, no_impact_casc, non_critical_casc, critical_casc,
+                          coverage_log) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);''',
                           (run_result.branch, run_result.commit, int(time.time()), run_result.total_tests,
                           run_result.passed_tests, run_result.total_instr, run_result.unique_instr,
                           run_result.errors, run_result.no_impact_err, run_result.non_critical_err,
@@ -88,14 +88,14 @@ class SQLiteDBAdapter:
     def insert_test_result(self, run_id, test_result):
         cursor = self.connection.cursor()
         cursor.execute('''INSERT INTO Tests (run_id, command, arguments, binary_hash, retcode,
-                          total_instr, unique_instr, diff_map, errors, no_impact_err, non_critical_err, 
-                          critical_err, cascades, no_impact_casc, non_critical_casc, critical_casc, 
-                          cascades_log, coverage_log) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);''', 
-                          (run_id, test_result.cfg.command, str(test_result.cfg.arguments), 
-                          test_result.binary_hash, test_result.retcode, test_result.total_instr, 
-                          test_result.unique_instr, test_result.diff_map, test_result.errors, 
-                          test_result.no_impact_err, test_result.non_critical_err, test_result.critical_err, 
-                          test_result.cascades, test_result.no_impact_casc, test_result.non_critical_casc, 
+                          total_instr, unique_instr, diff_map, errors, no_impact_err, non_critical_err,
+                          critical_err, cascades, no_impact_casc, non_critical_casc, critical_casc,
+                          cascades_log, coverage_log) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);''',
+                          (run_id, test_result.cfg.command, str(test_result.cfg.arguments),
+                          test_result.binary_hash, test_result.retcode, test_result.total_instr,
+                          test_result.unique_instr, test_result.diff_map, test_result.errors,
+                          test_result.no_impact_err, test_result.non_critical_err, test_result.critical_err,
+                          test_result.cascades, test_result.no_impact_casc, test_result.non_critical_casc,
                           test_result.critical_casc, test_result.cascades_log, test_result.coverage_log))
         run_id = cursor.lastrowid
         self.connection.commit()

--- a/tools/validation_runner/example.cfg
+++ b/tools/validation_runner/example.cfg
@@ -1,5 +1,5 @@
 threads: 2
-validator_path: /.../tools/validator/libvalidator2.so
+validator_path: ../../build/tools/validator/libvalidator.so
 database: test.db
 tests:
 # Filesystem

--- a/tools/validator/linux_validator.cpp
+++ b/tools/validator/linux_validator.cpp
@@ -34,59 +34,34 @@
 #include "Utility/LogSys.h"
 
 static const size_t STACK_SIZE = 8388608;
-static QBDI::GPRState ENTRY_GPR;
-static QBDI::FPRState ENTRY_FPR;
 static bool INSTRUMENTED = false;
+static pid_t debugged, instrumented;
 
 QBDIPRELOAD_INIT;
 
 
 int QBDI::qbdipreload_on_main(int argc, char** argv) {
-    QBDI::LOGSYS.addFilter("*", QBDI::LogPriority::DEBUG);
+    if (INSTRUMENTED) {
+        QBDI::LOGSYS.addFilter("*", QBDI::LogPriority::WARNING);
+        return QBDIPRELOAD_NOT_HANDLED;
 
-    QBDI::VM* vm = new QBDI::VM();
-    vm->instrumentAllExecutableMaps();
-    for(const QBDI::MemoryMap& m :  QBDI::getCurrentProcessMaps()) {
-        if((m.name.compare(0, 7, "libc-2.", 7) == 0) ||
-           (m.name.compare(0, 5, "ld-2.", 5) == 0)   ||
-           (m.name.compare(0, 7, "libcofi", 7) == 0)) {
-            vm->removeInstrumentedRange(m.range.start, m.range.end);
-        }
+    } else {
+        LinuxProcess* debuggedProcess = nullptr;
+        debuggedProcess = new LinuxProcess(debugged);
+        start_master(debuggedProcess, instrumented);
+        delete debuggedProcess;
+        return QBDIPRELOAD_NO_ERROR;
     }
-
-    vm->setGPRState(&ENTRY_GPR);
-    vm->setFPRState(&ENTRY_FPR);
-
-#if defined(__x86_64__)
-    QBDI::rword start = QBDI_GPR_GET(vm->getGPRState(), QBDI::REG_PC);
-    QBDI::rword stop = *((QBDI::rword*) QBDI_GPR_GET(vm->getGPRState(), QBDI::REG_SP));
-#elif defined(__arm__)
-    QBDI::rword start = QBDI_GPR_GET(vm->getGPRState(), QBDI::REG_PC);
-    QBDI::rword stop = QBDI_GPR_GET(vm->getGPRState(), QBDI::REG_LR);
-#endif
-    start_instrumented(vm, start, stop);
-
-    return QBDIPRELOAD_NO_ERROR;
 }
 
 int QBDI::qbdipreload_on_premain(void *gprCtx, void *fpuCtx) {
-    void* newStack = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-    ucontext_t* uap = (ucontext_t*) gprCtx;
-
-    qbdipreload_threadCtxToGPRState(uap, &ENTRY_GPR);
-    qbdipreload_floatCtxToFPRState(uap, &ENTRY_FPR);
-
-#if defined(QBDI_ARCH_X86_64)
-    uap->uc_mcontext.gregs[REG_RSP] = (uint64_t) newStack + STACK_SIZE - 8;
-    uap->uc_mcontext.gregs[REG_RBP] = (uint64_t) newStack + STACK_SIZE - 8;
-#elif defined(QBDI_ARCH_ARM)
-    uap->uc_mcontext.arm_sp = (uint32_t) newStack + STACK_SIZE - 8;
-    uap->uc_mcontext.arm_fp = (uint32_t) newStack + STACK_SIZE - 8;
-#endif
+    if (INSTRUMENTED)
+        return QBDIPRELOAD_NOT_HANDLED;
     return QBDIPRELOAD_NO_ERROR;
 }
 
 int QBDI::qbdipreload_on_run(QBDI::VMInstanceRef vm, QBDI::rword start, QBDI::rword stop) {
+    start_instrumented(vm, start, stop);
     return QBDIPRELOAD_NOT_HANDLED;
 }
 
@@ -98,27 +73,26 @@ int QBDI::qbdipreload_on_exit(int status) {
 }
 
 int QBDI::qbdipreload_on_start(void *main) {
-    pid_t debugged, instrumented;
-    LinuxProcess* debuggedProcess = nullptr;
+    setvbuf(stdin, NULL, _IONBF, 0);
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
 
     instrumented = fork();
     if(instrumented == 0) {
         INSTRUMENTED = true;
-		QBDI::qbdipreload_hook_main(main);
-        return QBDIPRELOAD_NO_ERROR;
+        return QBDIPRELOAD_NOT_HANDLED;
     }
     debugged = fork();
     if(debugged == 0) {
         ptrace(PTRACE_TRACEME, 0, NULL, NULL);
         return QBDIPRELOAD_NO_ERROR;
     }
-
-    debuggedProcess = new LinuxProcess(debugged);
     if (ptrace(PTRACE_ATTACH, debugged, NULL, NULL) == -1) {
         fprintf(stderr, "validator: fatal error, PTRACE_ATTACH failed !\n\n");
+        kill(instrumented, SIGKILL);
+        kill(debugged, SIGKILL);
+        exit(0);
     }
-    start_master(debuggedProcess, instrumented);
-    delete debuggedProcess;
 
     return QBDIPRELOAD_NOT_HANDLED;
 }

--- a/tools/validator/validatorengine.cpp
+++ b/tools/validator/validatorengine.cpp
@@ -76,9 +76,51 @@ ssize_t ValidatorEngine::logEntryLookup(uint64_t execID) {
 }
 
 void ValidatorEngine::outputLogEntry(const LogEntry& entry) {
-    fprintf(stderr, "ExecID: %" PRIu64 " \t%016" PRIRWORD ": %s\n", entry.execID, entry.address, entry.disassembly);
-    if(entry.transfer != 0)
-        fprintf(stderr, "\tCaused a transfer to address 0x%" PRIRWORD "\n", entry.transfer);
+    static QBDI::MemoryMap *module = nullptr;
+    static std::vector<QBDI::MemoryMap> memoryModule;
+
+    // try to find module name of current address
+    if (module != nullptr)
+        if (!module->range.contains(entry.address))
+            module = nullptr;
+
+    if (module == nullptr)
+        for (auto &m : memoryModule) {
+            if (m.range.contains(entry.address)) {
+                module = &m;
+                break;
+            }
+        }
+
+    if (module == nullptr) {
+        memoryModule.clear();
+        for (auto &m : QBDI::getRemoteProcessMaps(instrumented)) {
+            if (m.permission & QBDI::PF_EXEC) {
+                memoryModule.push_back(m);
+            }
+        }
+        for (auto &m : memoryModule) {
+            if (m.range.contains(entry.address)) {
+                module = &m;
+                break;
+            }
+        }
+    }
+
+    fprintf(stderr, "ExecID: %" PRIu64 " \t%25s 0x%016" PRIRWORD ": %s\n", entry.execID,
+            (module != nullptr) ? module->name.c_str() : "",
+            entry.address, entry.disassembly);
+    if(entry.transfer != 0) {
+        QBDI::MemoryMap *transfer_module = nullptr;
+        for (auto &m : memoryModule) {
+            if (m.range.contains(entry.transfer)) {
+                transfer_module = &m;
+                break;
+            }
+        }
+        fprintf(stderr, "\tCaused a transfer to address 0x%" PRIRWORD " %s\n", entry.transfer,
+                (transfer_module != nullptr) ? transfer_module->name.c_str() : "");
+    }
     for(ssize_t eID : entry.errorIDs) {
         if(errors[eID].severity == ErrorSeverity::NoImpact)
             fprintf(stderr, "\tError with no impact ");


### PR DESCRIPTION
- Add more log in validator runner in no optimal case (don't find some binary or git repository)
- In validator with verbosity FULL, return the name of current instruction module
- remove redundancy between QBDIPreload and linux validator
- QBDIPreload don't force log to DEBUG (only for Debug version). Log level can be set in qbdipreload_on_main

Minor Changes:
- Optimize a case in ExecBlock::writeSequence. If getEpilogueOffset() = MINIMAL_BLOCK_SIZE, we can reject before try to write.
- Typo in debug log