### PR TITLE
QBDIPreload for windows x64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,9 @@ if((${OS} STREQUAL "linux") OR (${OS} STREQUAL "android") OR (${OS} STREQUAL "ma
 else()
     set(HAS_QBDIPRELOAD false)
 endif()
+if(WIN32)
+    set(HAS_QBDIPRELOAD_WIN true)
+endif()
 
 # Configure install
 if(UNIX AND NOT ("${PLATFORM}" STREQUAL "android-ARM" OR "${PLATFORM}" STREQUAL "iOS-ARM"))

--- a/cmake/config-win-X86_64.py
+++ b/cmake/config-win-X86_64.py
@@ -1,7 +1,8 @@
 import subprocess
 
 subprocess.check_call(["cmake", "..",
-                       "-G", "Visual Studio 14 2015 Win64",
+                       "-G", "Visual Studio 16 2019",
+                       "-A", "x64",
                        "-DCMAKE_BUILD_TYPE=Release",
                        "-DCMAKE_CROSSCOMPILING=FALSE",
                        "-DPLATFORM=win-X86_64"])

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,4 +7,6 @@ if(HAS_QBDIPRELOAD)
 
     # Add pyqbdi
     add_subdirectory(pyqbdi)
+elseif(HAS_QBDIPRELOAD_WIN)
+    add_subdirectory(QBDIPreload)
 endif()

--- a/tools/QBDIPreload/CMakeLists.txt
+++ b/tools/QBDIPreload/CMakeLists.txt
@@ -2,6 +2,8 @@ set(SOURCES "")
 
 if((${OS} STREQUAL "linux") OR (${OS} STREQUAL "android"))
     set(SOURCES ${SOURCES} "src/linux_preload.c")
+elseif(WIN32)
+    set(SOURCES ${SOURCES} "src/win_preload.c")
 elseif(${OS} STREQUAL "macOS")
     # Generate MIG interface at config time in the build directory
     execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND mig /usr/include/mach/mach_exc.defs)

--- a/tools/QBDIPreload/CMakeLists.txt
+++ b/tools/QBDIPreload/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES "")
 if((${OS} STREQUAL "linux") OR (${OS} STREQUAL "android"))
     set(SOURCES ${SOURCES} "src/linux_preload.c")
 elseif(WIN32)
-    set(SOURCES ${SOURCES} "src/win_preload.c")
+    set(SOURCES ${SOURCES} "src/win_preload.c" "src/trampoline.asm")
 elseif(${OS} STREQUAL "macOS")
     # Generate MIG interface at config time in the build directory
     execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND mig /usr/include/mach/mach_exc.defs)

--- a/tools/QBDIPreload/include/QBDIPreload.h
+++ b/tools/QBDIPreload/include/QBDIPreload.h
@@ -34,18 +34,6 @@ extern "C" {
 #define QBDIPRELOAD_ERR_STARTUP_FAILED 2
 
 
-/**
- * A C pre-processor macro declaring a constructor.
- *
- * @warning `QBDIPRELOAD_INIT` must be used once in any project using QBDIPreload.
- * It declares a constructor, so it must be placed like a function declaration on a single line.
- */
-#ifdef __cplusplus
-#define QBDIPRELOAD_INIT __attribute__((constructor)) void init() { QBDI::qbdipreload_hook_init(); }
-#else
-#define QBDIPRELOAD_INIT __attribute__((constructor)) void init() { qbdipreload_hook_init(); }
-#endif
-
 /*
  * Public APIs
  */
@@ -129,11 +117,47 @@ extern int qbdipreload_on_exit(int status);
 /*
  * Private API
  */
-
+#ifdef WIN32
+#include <Windows.h>
+QBDI_EXPORT BOOLEAN qbdipreload_hook_init(DWORD nReason);
+#else
 QBDI_EXPORT int qbdipreload_hook_init();
+#endif
 
 QBDI_EXPORT void* qbdipreload_setup_exception_handler(uint32_t target, uint32_t mask, void* handler);
 
+/**
+ * A C pre-processor macro declaring a constructor.
+ *
+ * @warning `QBDIPRELOAD_INIT` must be used once in any project using QBDIPreload.
+ * It declares a constructor, so it must be placed like a function declaration on a single line.
+ */
+
+#ifdef __cplusplus
+
+#ifdef WIN32
+#define QBDIPRELOAD_INIT BOOLEAN WINAPI DllMain(HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved) \
+{ \
+    UNREFERENCED_PARAMETER(hDllHandle); \
+    UNREFERENCED_PARAMETER(Reserved); \
+    return QBDI::qbdipreload_hook_init(nReason); \
+}
+#else
+#define QBDIPRELOAD_INIT __attribute__((constructor)) void init() { QBDI::qbdipreload_hook_init(); }
+#endif
+
+#else
+#ifdef WIN32
+#define QBDIPRELOAD_INIT BOOLEAN WINAPI DllMain(HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved) \
+{ \
+    UNREFERENCED_PARAMETER(hDllHandle); \
+    UNREFERENCED_PARAMETER(Reserved); \
+    return qbdipreload_hook_init(nReason); \
+}
+#else
+#define QBDIPRELOAD_INIT __attribute__((constructor)) void init() { qbdipreload_hook_init(); }
+#endif
+#endif
 #ifdef __cplusplus
 } // "C"
 }

--- a/tools/QBDIPreload/src/trampoline.asm
+++ b/tools/QBDIPreload/src/trampoline.asm
@@ -1,9 +1,36 @@
+; This file is part of QBDI.
+;
+; Copyright 2017 Quarkslab
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 .code
 
+; Assembly exported trampoline
 PUBLIC qbdipreload_trampoline 
+
+; C trampoline destination import
 EXTERN qbdipreload_trampoline_impl : proc
+
+; Original app RSP (stack top) value when
+; entering start (PE EntryPoint)
 EXTERN g_shadowStackTop : QWORD
 
+; Trampoline stub
+; Update RSP and jump to trampoline implementation
+; (in C), g_shadowStackTop must be intiialized before
+; using the trampoline
+; Note that RBP is not used on x64
 qbdipreload_trampoline PROC
     mov rsp, g_shadowStackTop
     jmp qbdipreload_trampoline_impl

--- a/tools/QBDIPreload/src/trampoline.asm
+++ b/tools/QBDIPreload/src/trampoline.asm
@@ -5,7 +5,6 @@ EXTERN qbdipreload_trampoline_impl : proc
 EXTERN g_shadowStackTop : QWORD
 
 qbdipreload_trampoline PROC
-    mov rbp, g_shadowStackTop
     mov rsp, g_shadowStackTop
     jmp qbdipreload_trampoline_impl
 qbdipreload_trampoline ENDP

--- a/tools/QBDIPreload/src/trampoline.asm
+++ b/tools/QBDIPreload/src/trampoline.asm
@@ -1,0 +1,13 @@
+.code
+
+PUBLIC qbdipreload_trampoline 
+EXTERN qbdipreload_trampoline_impl : proc
+EXTERN g_shadowStackTop : QWORD
+
+qbdipreload_trampoline PROC
+    mov rbp, g_shadowStackTop
+    mov rsp, g_shadowStackTop
+    jmp qbdipreload_trampoline_impl
+qbdipreload_trampoline ENDP
+
+END

--- a/tools/QBDIPreload/src/trampoline.asm
+++ b/tools/QBDIPreload/src/trampoline.asm
@@ -1,6 +1,6 @@
 ; This file is part of QBDI.
 ;
-; Copyright 2017 Quarkslab
+; Copyright 2019 Quarkslab
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.

--- a/tools/QBDIPreload/src/win_preload.c
+++ b/tools/QBDIPreload/src/win_preload.c
@@ -24,7 +24,6 @@ static GPRState g_EntryPointGPRState;   /* QBDI CPU GPR states when EntryPoint h
 static FPRState g_EntryPointFPRState;   /* QBDI CPU FPR states when EntryPoint has been reached */
 
 
-
 /*
  * Conversion from windows CONTEXT ARCH dependent structure 
  * to QBDI GPR state (Global purpose registers)
@@ -245,14 +244,6 @@ void* getMainModuleEntryPoint() {
 }
 
 /*
- * Unused on windows as DllMain() already provides
- * code execution at start
- */
-int qbdipreload_hook_init() {
-    return QBDIPRELOAD_NO_ERROR;
-}
-
-/*
  * Hooking based on int1 instruction + exception handler
  * Return 0 in case of failure
  */
@@ -268,9 +259,10 @@ int qbdipreload_hook(void* va) {
  * QBDI windows preload installation is done automatically
  * through DLLMain() once the QBDI instrumentation module
  * is loaded inside target (e.g. with LoadLibrary)
+ * This function is automatically called when user use
+ * QBDIPRELOAD_INIT macro
  */
-BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved)
-{
+BOOLEAN qbdipreload_hook_init(DWORD nReason) {
     if(nReason == DLL_PROCESS_ATTACH) {
         void* mainmod_entry_point = getMainModuleEntryPoint();
         // Call user provided callback

--- a/tools/QBDIPreload/src/win_preload.c
+++ b/tools/QBDIPreload/src/win_preload.c
@@ -1,0 +1,80 @@
+#include "QBDIPreload.h"
+#include <Windows.h>
+#include <winnt.h>
+
+/*
+ * Conversion from windows CONTEXT ARCH dependent structure 
+ * to QBDI GPR state (Global purpose registers)
+ */
+void qbdipreload_threadCtxToGPRState(const void* gprCtx, GPRState* gprState) {
+    PCONTEXT x64cpu = (PCONTEXT) gprCtx;
+
+    gprState->rax = x64cpu->Rax;
+    gprState->rbx = x64cpu->Rbx;
+    gprState->rcx = x64cpu->Rcx;
+    gprState->rdx = x64cpu->Rdx;
+    gprState->rsi = x64cpu->Rsi;
+    gprState->rdi = x64cpu->Rdi;
+    gprState->rbp = x64cpu->Rbp;
+    gprState->rsp = x64cpu->Rsp;
+    gprState->r8 = x64cpu->R8;
+    gprState->r9 = x64cpu->R9;
+    gprState->r10 = x64cpu->R10;
+    gprState->r11 = x64cpu->R11;
+    gprState->r12 = x64cpu->R12;
+    gprState->r13 = x64cpu->R13;
+    gprState->r14 = x64cpu->R14;
+    gprState->r15 = x64cpu->R15;
+    gprState->rip = x64cpu->Rip;
+    gprState->eflags = x64cpu->EFlags;
+}
+
+/*
+ * Conversion from windows CONTEXT ARCH dependent structure 
+ * to QBDI FPR state (Floating point registers)
+ */
+void qbdipreload_floatCtxToFPRState(const void* gprCtx, FPRState* fprState) {
+     PCONTEXT x64cpu = (PCONTEXT) gprCtx;
+
+    // FPU STmm(X)
+    memcpy(&fprState->stmm0, &x64cpu->FltSave.FloatRegisters[0], sizeof(MMSTReg));
+    memcpy(&fprState->stmm1, &x64cpu->FltSave.FloatRegisters[1], sizeof(MMSTReg));
+    memcpy(&fprState->stmm2, &x64cpu->FltSave.FloatRegisters[2], sizeof(MMSTReg));
+    memcpy(&fprState->stmm3, &x64cpu->FltSave.FloatRegisters[3], sizeof(MMSTReg));
+    memcpy(&fprState->stmm4, &x64cpu->FltSave.FloatRegisters[4], sizeof(MMSTReg));
+    memcpy(&fprState->stmm5, &x64cpu->FltSave.FloatRegisters[5], sizeof(MMSTReg));
+    memcpy(&fprState->stmm6, &x64cpu->FltSave.FloatRegisters[6], sizeof(MMSTReg));
+    memcpy(&fprState->stmm7, &x64cpu->FltSave.FloatRegisters[7], sizeof(MMSTReg));
+
+    // XMM(X) registers
+    memcpy(&fprState->xmm0, &x64cpu->Xmm0, 16);
+    memcpy(&fprState->xmm1, &x64cpu->Xmm1, 16);
+    memcpy(&fprState->xmm2, &x64cpu->Xmm2, 16);
+    memcpy(&fprState->xmm3, &x64cpu->Xmm3, 16);
+    memcpy(&fprState->xmm4, &x64cpu->Xmm4, 16);
+    memcpy(&fprState->xmm5, &x64cpu->Xmm5, 16);
+    memcpy(&fprState->xmm6, &x64cpu->Xmm6, 16);
+    memcpy(&fprState->xmm7, &x64cpu->Xmm7, 16);
+    memcpy(&fprState->xmm8, &x64cpu->Xmm8, 16);
+    memcpy(&fprState->xmm9, &x64cpu->Xmm9, 16);
+    memcpy(&fprState->xmm10, &x64cpu->Xmm10, 16);
+    memcpy(&fprState->xmm11, &x64cpu->Xmm11, 16);
+    memcpy(&fprState->xmm12, &x64cpu->Xmm12, 16);
+    memcpy(&fprState->xmm13, &x64cpu->Xmm13, 16);
+    memcpy(&fprState->xmm14, &x64cpu->Xmm14, 16);
+    memcpy(&fprState->xmm15, &x64cpu->Xmm15, 16);
+
+    // Others FPU registers
+    fprState->rfcw = x64cpu->FltSave.ControlWord;
+    fprState->rfsw = x64cpu->FltSave.StatusWord;
+    fprState->ftw  = x64cpu->FltSave.TagWord;
+    fprState->rsrv1 = x64cpu->FltSave.Reserved1;
+    fprState->ip =  x64cpu->FltSave.ErrorOffset;
+    fprState->cs =  x64cpu->FltSave.ErrorSelector;
+    fprState->rsrv2 = x64cpu->FltSave.Reserved2;
+    fprState->dp =  x64cpu->FltSave.DataOffset;
+    fprState->ds =  x64cpu->FltSave.DataSelector;
+    fprState->rsrv3 = x64cpu->FltSave.Reserved3;
+    fprState->mxcsr = x64cpu->FltSave.MxCsr;
+    fprState->mxcsrmask =  x64cpu->FltSave.MxCsr_Mask;
+ }

--- a/tools/QBDIPreload/src/win_preload.c
+++ b/tools/QBDIPreload/src/win_preload.c
@@ -226,6 +226,7 @@ LONG WINAPI QbdiPreloadExceptionFilter(PEXCEPTION_POINTERS exc_info) {
 
         // Continue execution on trampoline to make QBDI runtime
         // execute using a separate stack and not instrumented target one
+         // RSP can't be set here (system seems to validate pointer authenticity)
         x64cpu->Rip = (uint64_t) qbdipreload_trampoline;
     }
 

--- a/tools/QBDIPreload/src/win_preload.c
+++ b/tools/QBDIPreload/src/win_preload.c
@@ -2,6 +2,29 @@
 #include <Windows.h>
 #include <winnt.h>
 
+/* Consts */
+static const unsigned long INST_INT1 = 0x01CD;          /* Instruction opcode for "INT 1" */
+static const unsigned long INST_INT1_MASK = 0xFFFF;
+static const size_t QBDI_RUNTIME_STACK_SIZE = 0x800000; /* QBDI shadow stack size         */
+static const long MEM_PAGE_SIZE = 4096;                 /* Default page size on Windows   */
+
+/* Trampoline spec (to be called from assembly stub) */
+void qbdipreload_trampoline();
+
+/* Globals */
+static struct {
+    void* va;
+    uint64_t orig_bytes;
+} g_EntryPointInfo;                     /* Main module EntryPoint (PE from host process)        */
+static PVOID g_hExceptionHandler;       /* VEH for QBDI preload internals (break on EntryPoint) */
+static rword g_firstInstructionVA;      /* First instruction that will be executed by QBDI      */
+static rword g_lastInstructionVA;       /* Last instruction that will be executed by QBDI       */
+PVOID g_shadowStackTop;                 /* QBDI shadow stack top pointer(decreasing address)    */
+static GPRState g_EntryPointGPRState;   /* QBDI CPU GPR states when EntryPoint has been reached */
+static FPRState g_EntryPointFPRState;   /* QBDI CPU FPR states when EntryPoint has been reached */
+
+
+
 /*
  * Conversion from windows CONTEXT ARCH dependent structure 
  * to QBDI GPR state (Global purpose registers)
@@ -78,3 +101,190 @@ void qbdipreload_floatCtxToFPRState(const void* gprCtx, FPRState* fprState) {
     fprState->mxcsr = x64cpu->FltSave.MxCsr;
     fprState->mxcsrmask =  x64cpu->FltSave.MxCsr_Mask;
  }
+
+/*
+ * Write an "int 1" instruction at given address
+ * Save previous byte to internal buffer
+ * return 0 in case of failure
+ */
+int setInt1Exception(void* fn_va) {
+     DWORD oldmemprot;
+
+    if (!fn_va){
+        return 0;
+    }
+
+    uintptr_t base = (uintptr_t) fn_va - ((uintptr_t) fn_va % MEM_PAGE_SIZE);
+    
+    g_EntryPointInfo.va = fn_va;
+    if(!VirtualProtect((void*) base, MEM_PAGE_SIZE, PAGE_READWRITE, &oldmemprot))
+        return 0;
+    g_EntryPointInfo.orig_bytes = *(uint64_t*) fn_va;
+    *(uint64_t*) fn_va = INST_INT1 | (g_EntryPointInfo.orig_bytes & (~(uint64_t)INST_INT1_MASK));
+    
+    return VirtualProtect((void*) base, MEM_PAGE_SIZE, oldmemprot, &oldmemprot) != 0;
+}
+
+/*
+ * Restore original bytes on a previously installed "int 1" instruction
+ * return 0 in case of failure
+ */
+int unsetInt1Exception() {
+	DWORD oldmemprot;
+    uintptr_t base = (uintptr_t) g_EntryPointInfo.va - ((uintptr_t) g_EntryPointInfo.va % MEM_PAGE_SIZE);
+
+    if(!VirtualProtect((void*) base, MEM_PAGE_SIZE, PAGE_READWRITE, &oldmemprot))
+        return 0;
+    
+    *(uint64_t*) g_EntryPointInfo.va = g_EntryPointInfo.orig_bytes;
+    
+    return VirtualProtect((void*) base, MEM_PAGE_SIZE, oldmemprot, &oldmemprot) != 0;
+}
+
+/*
+ * Remove a previously installed vectored exception handler
+ * Return 0 in case of failure
+ */
+int unsetExceptionHandler(LONG (*exception_filter_fn)(PEXCEPTION_POINTERS)) {
+    return RemoveVectoredExceptionHandler(exception_filter_fn);
+}
+
+/*
+ * Install a vectored exception handler
+ * Return 0 in case of failure
+ */
+int setExceptionHandler(LONG (*exception_filter_fn)(PEXCEPTION_POINTERS)) {
+    
+    g_hExceptionHandler = AddVectoredExceptionHandler(1, exception_filter_fn);
+    return g_hExceptionHandler != NULL;
+}
+
+/*
+ * Trampoline implementation
+ * It removes exception handler, restore entry point bytes and 
+ * setup QBDI runtime for host target
+ * Its is called from separate qbdipreload_trampoline() assembly stub that
+ * makes this function load in a arbitraty allocated stack, then QBDI can
+ * safely initialize & instrument main target thread
+ */
+void qbdipreload_trampoline_impl() {
+    unsetInt1Exception();
+    unsetExceptionHandler(g_hExceptionHandler);
+
+    int status = qbdipreload_on_main(0, NULL);
+    
+    if(status == QBDIPRELOAD_NOT_HANDLED) {
+        VMInstanceRef vm;
+        qbdi_initVM(&vm, NULL, NULL);
+    
+        // Filter some modules to avoid conflicts
+        qbdi_removeAllInstrumentedRanges(vm);
+
+        // Set original states
+        qbdi_setGPRState(vm, &g_EntryPointGPRState);
+        qbdi_setFPRState(vm, &g_EntryPointFPRState);
+
+        status = qbdipreload_on_run(vm, g_firstInstructionVA, g_lastInstructionVA);
+    }
+
+    // Exiting early must be done as qbdipreload_trampoline_impl
+    // is executed on fake stack without any caller
+    // It will trigger DLL_PROCESS_DETACH event in DLLMain()
+    ExitProcess(status);
+}
+
+/*
+ * Windows QBDI preload specific excetion handler
+ * It must be uninstalled once used one time
+ * The handler catches the first INT1 exception
+ */
+LONG WINAPI QbdiPreloadExceptionFilter(PEXCEPTION_POINTERS exc_info) {
+    PCONTEXT x64cpu = exc_info->ContextRecord;
+
+    // Sanity check on exception
+    if((exc_info->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) &&
+        (x64cpu->Rip == (DWORD64) g_EntryPointInfo.va)) {
+        // Call user provided callback with x64 cpu state (specific to windows)
+        int status = qbdipreload_on_premain((void*) x64cpu, (void*) x64cpu);
+
+        // Convert windows CPU context to QBDIGPR/FPR states
+        qbdipreload_threadCtxToGPRState(x64cpu, &g_EntryPointGPRState);
+        qbdipreload_floatCtxToFPRState(x64cpu, &g_EntryPointFPRState);
+
+        // First instruction to execute is main module entry point)
+        g_firstInstructionVA = QBDI_GPR_GET(&g_EntryPointGPRState, REG_PC);
+
+        // Last instruction to execute is inside windows PE loader
+        // (inside BaseThreadInitThunk() who called PE entry point & set RIP on stack) 
+        g_lastInstructionVA =  *((rword*) QBDI_GPR_GET(&g_EntryPointGPRState, REG_SP));
+
+        if (status == QBDIPRELOAD_NOT_HANDLED) {
+            // Allocate shadow stack & keep some space at the end for QBDI runtime
+            g_shadowStackTop = VirtualAlloc(NULL, QBDI_RUNTIME_STACK_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            g_shadowStackTop = (PVOID) ((uint64_t) g_shadowStackTop + QBDI_RUNTIME_STACK_SIZE - 0x1008);
+        }
+
+        // Continue execution on trampoline to make QBDI runtime
+        // execute using a separate stack and not instrumented target one
+        x64cpu->Rip = (uint64_t) qbdipreload_trampoline;
+    }
+
+    return EXCEPTION_CONTINUE_EXECUTION;
+}
+
+/*
+ * Get main module entry point
+ */
+void* getMainModuleEntryPoint() {
+    PIMAGE_DOS_HEADER mainmod_imgbase = (PIMAGE_DOS_HEADER) GetModuleHandle(NULL);
+    PIMAGE_NT_HEADERS  mainmod_nt = (PIMAGE_NT_HEADERS) ((uint8_t*)mainmod_imgbase + mainmod_imgbase->e_lfanew);
+    
+    return (void*) ((uint8_t*) mainmod_imgbase + mainmod_nt->OptionalHeader.AddressOfEntryPoint);
+    
+}
+
+/*
+ * Unused on windows as DllMain() already provides
+ * code execution at start
+ */
+int qbdipreload_hook_init() {
+    return QBDIPRELOAD_NO_ERROR;
+}
+
+/*
+ * Hooking based on int1 instruction + exception handler
+ * Return 0 in case of failure
+ */
+int qbdipreload_hook(void* va) {
+    if(!setInt1Exception(va)) {
+        return 0;
+    }
+
+    return !setExceptionHandler(QbdiPreloadExceptionFilter);
+}
+
+/*
+ * QBDI windows preload installation is done automatically
+ * through DLLMain() once the QBDI instrumentation module
+ * is loaded inside target (e.g. with LoadLibrary)
+ */
+BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, DWORD nReason, LPVOID Reserved)
+{
+    if(nReason == DLL_PROCESS_ATTACH) {
+        void* mainmod_entry_point = getMainModuleEntryPoint();
+        // Call user provided callback
+        int status = qbdipreload_on_start(mainmod_entry_point);
+        if (status == QBDIPRELOAD_NOT_HANDLED) {
+            // QBDI preload installation
+            qbdipreload_hook(mainmod_entry_point);
+        }
+    }
+    else if(nReason == DLL_PROCESS_DETACH) {
+        DWORD dwExitCode;
+
+        GetExitCodeProcess(GetCurrentProcess(), &dwExitCode);
+        qbdipreload_on_exit(dwExitCode);
+    }
+
+    return TRUE;
+}


### PR DESCRIPTION
Make it possible to use QBDI to instrument windows PE executable from entry point
An external injector is needed as Linux version (based on LD_PRELOAD) to inject QBDIPreload at process creation.