### PR TITLE
Fix Android Compilation

### DIFF
--- a/cmake/config-android-ARM.sh
+++ b/cmake/config-android-ARM.sh
@@ -14,6 +14,6 @@ export NDK_PATH=${QBDI_NDK_PATH}
 cmake  .. \
       -DPLATFORM=android-ARM \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_TOOLCHAIN_FILE="${NDK_PATH}/build/cmake/android.toolchain.cmake"
+      -DCMAKE_TOOLCHAIN_FILE="${NDK_PATH}/build/cmake/android.toolchain.cmake" \
       -DANDROID_ABI=armeabi-v7a \
       -DANDROID_PLATFORM=23

--- a/deps/gtest/android-ARM/build.sh
+++ b/deps/gtest/android-ARM/build.sh
@@ -3,6 +3,17 @@
 VERSION="1.7.0"
 SOURCE_URL="https://github.com/google/googletest/archive/release-${VERSION}.tar.gz"
 
+DEFAULT_NDK_PATH=${HOME}/android-ndk-r20
+QBDI_NDK_PATH=${NDK_PATH:-${DEFAULT_NDK_PATH}}
+
+if [ ! -d "$QBDI_NDK_PATH" ]; then
+  echo "'${QBDI_NDK_PATH}' is not valid!"
+  exit 1
+fi
+
+export NDK_PATH=${QBDI_NDK_PATH}
+
+
 case "$1" in
 
     prepare)
@@ -13,7 +24,7 @@ case "$1" in
     build)
         mkdir -p build
         cd build
-        NDK_PATH=${HOME}/android-ndk-r20
+        # NDK_PATH=${HOME}/android-ndk-r20
         cmake "../googletest-release-${VERSION}" \
               -DCMAKE_TOOLCHAIN_FILE="${NDK_PATH}/build/cmake/android.toolchain.cmake"
         make -j4

--- a/deps/gtest/android-X86/build.sh
+++ b/deps/gtest/android-X86/build.sh
@@ -3,6 +3,16 @@
 VERSION="1.7.0"
 SOURCE_URL="https://github.com/google/googletest/archive/release-${VERSION}.tar.gz"
 
+DEFAULT_NDK_PATH=${HOME}/android-ndk-r20
+QBDI_NDK_PATH=${NDK_PATH:-${DEFAULT_NDK_PATH}}
+
+if [ ! -d "$QBDI_NDK_PATH" ]; then
+  echo "'${QBDI_NDK_PATH}' is not valid!"
+  exit 1
+fi
+
+export NDK_PATH=${QBDI_NDK_PATH}
+
 case "$1" in
 
     prepare)
@@ -13,7 +23,7 @@ case "$1" in
     build)
         mkdir -p build
         cd build
-        NDK_PATH=${HOME}/android-ndk-r20
+        # NDK_PATH=${HOME}/android-ndk-r20
         cmake "../googletest-release-${VERSION}" \
               -DCMAKE_TOOLCHAIN_FILE="${NDK_PATH}/build/cmake/android.toolchain.cmake" \
               -DANDROID_ABI=x86 \

--- a/deps/gtest/android-X86_64/build.sh
+++ b/deps/gtest/android-X86_64/build.sh
@@ -3,6 +3,16 @@
 VERSION="1.7.0"
 SOURCE_URL="https://github.com/google/googletest/archive/release-${VERSION}.tar.gz"
 
+DEFAULT_NDK_PATH=${HOME}/android-ndk-r20
+QBDI_NDK_PATH=${NDK_PATH:-${DEFAULT_NDK_PATH}}
+
+if [ ! -d "$QBDI_NDK_PATH" ]; then
+  echo "'${QBDI_NDK_PATH}' is not valid!"
+  exit 1
+fi
+
+export NDK_PATH=${QBDI_NDK_PATH}
+
 case "$1" in
 
     prepare)
@@ -13,7 +23,7 @@ case "$1" in
     build)
         mkdir -p build
         cd build
-        NDK_PATH=${HOME}/android-ndk-r20
+        # NDK_PATH=${HOME}/android-ndk-r20
         cmake "../googletest-release-${VERSION}" \
               -DCMAKE_TOOLCHAIN_FILE="${NDK_PATH}/build/cmake/android.toolchain.cmake" \
               -DANDROID_ABI=x86_64 \


### PR DESCRIPTION
```sh
# install cmake ninja (...)

export ANDROID_NDK=/path/to/r20b

cd QBDI
mkdir build && cd build

NDK_PATH=ANDROID_NDK ../cmake/config-android-ARM.sh
NDK_PATH=ANDROID_NDK make llvm
NDK_PATH=ANDROID_NDK make gtest
NDK_PATH=ANDROID_NDK make QBDI
NDK_PATH=ANDROID_NDK make QBDI_static
```