### PR TITLE
Fix/pusha popa

### DIFF
--- a/src/Patch/ARM/InstInfo_ARM.cpp
+++ b/src/Patch/ARM/InstInfo_ARM.cpp
@@ -49,4 +49,8 @@ unsigned getImmediateSize(const llvm::MCInst* inst, const llvm::MCInstrDesc* des
     return sizeof(rword);
 }
 
+bool useAllRegisters(const llvm::MCInst* inst) {
+    return false;
+}
+
 };

--- a/src/Patch/InstInfo.h
+++ b/src/Patch/InstInfo.h
@@ -31,6 +31,10 @@ bool isStackWrite(const llvm::MCInst* inst);
 
 unsigned getImmediateSize(const llvm::MCInst* inst, const llvm::MCInstrDesc* desc);
 
+// The TempManager will allow to reuse some register
+// when the method return True.
+bool useAllRegisters(const llvm::MCInst* inst);
+
 };
 
 #endif // INSTCLASSES_H

--- a/src/Patch/InstrRule.cpp
+++ b/src/Patch/InstrRule.cpp
@@ -30,7 +30,7 @@ void InstrRule::instrument(Patch &patch, llvm::MCInstrInfo* MCII, llvm::MCRegist
      * host.
     */
     RelocatableInst::SharedPtrVec instru;
-    TempManager tempManager(&patch.metadata.inst, MCII, MRI);
+    TempManager tempManager(&patch.metadata.inst, MCII, MRI, true);
 
     // Generate the instrumentation code from the original instruction context
     for(PatchGenerator::SharedPtr& g : patchGen) {

--- a/src/Patch/PatchUtils.cpp
+++ b/src/Patch/PatchUtils.cpp
@@ -18,6 +18,7 @@
 
 #include "Platform.h"
 #include "Patch/PatchUtils.h"
+#include "Patch/InstInfo.h"
 #include "Utility/LogSys.h"
 
 #if defined(QBDI_ARCH_X86_64) || defined(QBDI_ARCH_X86)
@@ -90,8 +91,7 @@ Reg TempManager::getRegForTemp(unsigned int id) {
     }
 
     // bypass for pusha and popa. MemoryAccess will not work on theses instruction
-    if(allowInstRegister) {
-        LogWarning("TempManager::getRegForTemp", "No free registers found, reuse one used by the instruction");
+    if(allowInstRegister and useAllRegisters(inst)) {
         if(temps.size() > 0) {
             i = temps.back().second + 1;
         }

--- a/src/Patch/PatchUtils.cpp
+++ b/src/Patch/PatchUtils.cpp
@@ -88,6 +88,22 @@ Reg TempManager::getRegForTemp(unsigned int id) {
             return Reg(i);
         }
     }
+
+    // bypass for pusha and popa. MemoryAccess will not work on theses instruction
+    if(allowInstRegister) {
+        LogWarning("TempManager::getRegForTemp", "No free registers found, reuse one used by the instruction");
+        if(temps.size() > 0) {
+            i = temps.back().second + 1;
+        }
+        else {
+            i = _QBDI_FIRST_FREE_REGISTER;
+        }
+        // store it and return it
+        if (i < AVAILABLE_GPR) {
+            temps.push_back(std::make_pair(id, i));
+            return Reg(i);
+        }
+    }
     LogError("TempManager::getRegForTemp", "No free registers found");
     abort();
 }

--- a/src/Patch/PatchUtils.h
+++ b/src/Patch/PatchUtils.h
@@ -73,10 +73,12 @@ class TempManager {
     const llvm::MCInst* inst;
     llvm::MCInstrInfo* MCII;
     llvm::MCRegisterInfo* MRI;
+    bool allowInstRegister;
 
 public:
 
-    TempManager(const llvm::MCInst *inst, llvm::MCInstrInfo* MCII, llvm::MCRegisterInfo *MRI) : inst(inst), MCII(MCII), MRI(MRI) {};
+    TempManager(const llvm::MCInst *inst, llvm::MCInstrInfo* MCII, llvm::MCRegisterInfo *MRI, bool allowInstRegister=false)
+        : inst(inst), MCII(MCII), MRI(MRI), allowInstRegister(allowInstRegister) {};
 
     Reg getRegForTemp(unsigned int id);
 

--- a/src/Patch/X86_64/InstInfo_X86_64.cpp
+++ b/src/Patch/X86_64/InstInfo_X86_64.cpp
@@ -1115,4 +1115,23 @@ unsigned getImmediateSize(const llvm::MCInst* inst, const llvm::MCInstrDesc* des
     }
 }
 
+bool useAllRegisters(const llvm::MCInst* inst) {
+    const unsigned InstAllRegisters[] = {
+#ifdef QBDI_ARCH_X86
+        llvm::X86::PUSHA16,
+        llvm::X86::PUSHA32,
+        llvm::X86::POPA16,
+        llvm::X86::POPA32
+#endif
+    };
+    unsigned opcode = inst->getOpcode();
+
+    for (unsigned op : InstAllRegisters) {
+        if (op == opcode)
+            return true;
+    }
+
+    return false;
+}
+
 };

--- a/src/Patch/X86_64/InstInfo_X86_64.cpp
+++ b/src/Patch/X86_64/InstInfo_X86_64.cpp
@@ -1116,13 +1116,14 @@ unsigned getImmediateSize(const llvm::MCInst* inst, const llvm::MCInstrDesc* des
 }
 
 bool useAllRegisters(const llvm::MCInst* inst) {
-    const unsigned InstAllRegisters[] = {
+// cannot allocate an array of constant size 0 on windows, just
+// skip the check on x64
 #ifdef QBDI_ARCH_X86
+    static const unsigned InstAllRegisters[] = {
         llvm::X86::PUSHA16,
         llvm::X86::PUSHA32,
         llvm::X86::POPA16,
         llvm::X86::POPA32
-#endif
     };
     unsigned opcode = inst->getOpcode();
 
@@ -1130,6 +1131,7 @@ bool useAllRegisters(const llvm::MCInst* inst) {
         if (op == opcode)
             return true;
     }
+#endif
 
     return false;
 }

--- a/test/Patch/ComparedExecutor_X86.cpp
+++ b/test/Patch/ComparedExecutor_X86.cpp
@@ -146,6 +146,8 @@ const char* GPRSave_s =
         "    mov $0x6, %edi\n";
 
 const char* GPRShuffle_s =
+        "    pushal\n"
+        "    popal\n"
         "    push %eax\n"
         "    push %ebx\n"
         "    push %ecx\n"


### PR DESCRIPTION
On X86, Pusha and Popa use all available register. When the a callback is set on these instructions, some temporary registers are needed to prepare the callback.

This patch allows to reuse instructions registers in the instrumentation patch (not in the patch of the instruction). This only happend if no others registers are available.