### PR TITLE
Fix getBBMemoryAccess

### DIFF
--- a/include/QBDI/VM.h
+++ b/include/QBDI/VM.h
@@ -260,9 +260,9 @@ class QBDI_EXPORT VM {
      * in case of failure).
      */
     uint32_t    addMemAccessCB(MemoryAccessType type, InstCallback cbk, void *data);
-    
-    /*! Add a virtual callback which is triggered for any memory access at a specific address 
-     *  matching the access type. Virtual callbacks are called via callback forwarding by a 
+
+    /*! Add a virtual callback which is triggered for any memory access at a specific address
+     *  matching the access type. Virtual callbacks are called via callback forwarding by a
      *  gate callback triggered on every memory access. This incurs a high performance cost.
      *
      * @param[in] address  Code address which will trigger the callback.
@@ -276,8 +276,8 @@ class QBDI_EXPORT VM {
      */
     uint32_t    addMemAddrCB(rword address, MemoryAccessType type, InstCallback cbk, void *data);
 
-    /*! Add a virtual callback which is triggered for any memory access in a specific address range 
-     *  matching the access type. Virtual callbacks are called via callback forwarding by a 
+    /*! Add a virtual callback which is triggered for any memory access in a specific address range
+     *  matching the access type. Virtual callbacks are called via callback forwarding by a
      *  gate callback triggered on every memory access. This incurs a high performance cost.
      *
      * @param[in] start    Start of the address range which will trigger the callback.
@@ -318,7 +318,7 @@ class QBDI_EXPORT VM {
     void        deleteAllInstrumentations();
 
     /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
-     *  The validity of the returned pointer is only guaranteed until the end of the callback, else 
+     *  The validity of the returned pointer is only guaranteed until the end of the callback, else
      *  a deepcopy of the structure is required.
      *
      * @param[in] [type]         Properties to retrieve during analysis.
@@ -340,12 +340,14 @@ class QBDI_EXPORT VM {
     bool recordMemoryAccess(MemoryAccessType type);
 
     /*! Obtain the memory accesses made by the last executed instruction.
+     *  The method should be called in an InstCallback.
      *
      * @return List of memory access made by the instruction.
      */
     std::vector<MemoryAccess> getInstMemoryAccess() const;
 
     /*! Obtain the memory accesses made by the last executed basic block.
+     *  The method should be called in a VMCallback with VMEvent::SEQUENCE_EXIT.
      *
      * @return List of memory access made by the instruction.
      */

--- a/include/QBDI/VM_C.h
+++ b/include/QBDI/VM_C.h
@@ -76,7 +76,7 @@ QBDI_EXPORT bool qbdi_addInstrumentedModule(VMInstanceRef instance, const char* 
  */
 QBDI_EXPORT bool qbdi_addInstrumentedModuleFromAddr(VMInstanceRef instance, rword addr);
 
-/*! Adds all the executable memory maps to the instrumented range set. 
+/*! Adds all the executable memory maps to the instrumented range set.
  *
  * @param[in] instance VM instance.
  *
@@ -218,8 +218,8 @@ QBDI_EXPORT void qbdi_setFPRState(VMInstanceRef instance, FPRState* fprState);
  */
 QBDI_EXPORT uint32_t qbdi_addMemAccessCB(VMInstanceRef instance, MemoryAccessType type, InstCallback cbk, void *data);
 
-/*! Add a virtual callback which is triggered for any memory access at a specific address 
- *  matching the access type. Virtual callbacks are called via callback forwarding by a 
+/*! Add a virtual callback which is triggered for any memory access at a specific address
+ *  matching the access type. Virtual callbacks are called via callback forwarding by a
  *  gate callback triggered on every memory access. This incurs a high performance cost.
  *
  * @param[in] instance  VM instance.
@@ -233,8 +233,8 @@ QBDI_EXPORT uint32_t qbdi_addMemAccessCB(VMInstanceRef instance, MemoryAccessTyp
  */
 QBDI_EXPORT uint32_t qbdi_addMemAddrCB(VMInstanceRef instance, rword address, MemoryAccessType type, InstCallback cbk, void *data);
 
-/*! Add a virtual callback which is triggered for any memory access in a specific address range 
- *  matching the access type. Virtual callbacks are called via callback forwarding by a 
+/*! Add a virtual callback which is triggered for any memory access in a specific address range
+ *  matching the access type. Virtual callbacks are called via callback forwarding by a
  *  gate callback triggered on every memory access. This incurs a high performance cost.
  *
  * @param[in] instance  VM instance.
@@ -329,7 +329,7 @@ QBDI_EXPORT bool qbdi_deleteInstrumentation(VMInstanceRef instance, uint32_t id)
 QBDI_EXPORT void qbdi_deleteAllInstrumentations(VMInstanceRef instance);
 
  /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
- *  The validity of the returned pointer is only guaranteed until the end of the callback, else 
+ *  The validity of the returned pointer is only guaranteed until the end of the callback, else
  *  a deepcopy of the structure is required.
  *
  * @param[in] instance     VM instance.
@@ -339,11 +339,11 @@ QBDI_EXPORT void qbdi_deleteAllInstrumentations(VMInstanceRef instance);
  */
 QBDI_EXPORT const InstAnalysis* qbdi_getInstAnalysis(VMInstanceRef instance, AnalysisType type);
 
-/*! Add instrumentation rules to log memory access using inline instrumentation and 
+/*! Add instrumentation rules to log memory access using inline instrumentation and
  *  instruction shadows.
 
  * @param[in] instance  VM instance.
- * @param[in] type      Memory mode bitfield to activate the logging for: either QBDI_MEMORY_READ, 
+ * @param[in] type      Memory mode bitfield to activate the logging for: either QBDI_MEMORY_READ,
  *                      QBDI_MEMORY_WRITE or both (QBDI_MEMORY_READ_WRITE).
  *
  * @return True if inline memory logging is supported, False if not or in case of error.
@@ -351,6 +351,7 @@ QBDI_EXPORT const InstAnalysis* qbdi_getInstAnalysis(VMInstanceRef instance, Ana
 QBDI_EXPORT bool qbdi_recordMemoryAccess(VMInstanceRef instance, MemoryAccessType type);
 
 /*! Obtain the memory accesses made by the last executed instruction.
+ *  The method should be called in an InstCallback.
  *  Return NULL and a size of 0 if the instruction made no memory access.
  *
  *  @param[in]  instance     VM instance.
@@ -361,6 +362,7 @@ QBDI_EXPORT bool qbdi_recordMemoryAccess(VMInstanceRef instance, MemoryAccessTyp
 QBDI_EXPORT MemoryAccess* qbdi_getInstMemoryAccess(VMInstanceRef instance, size_t* size);
 
 /*! Obtain the memory accesses made by the last executed basic block.
+ *  The method should be called in a VMCallback with QBDI_SEQUENCE_EXIT.
  *  Return NULL and a size of 0 if the basic block made no memory access.
  *
  *  @param[in]  instance     VM instance.

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -410,16 +410,24 @@ bool Engine::run(rword start, rword stop) {
     return hasRan;
 }
 
-uint32_t Engine::addInstrRule(InstrRule rule) {
+uint32_t Engine::addInstrRule(InstrRule rule, bool top_list) {
     uint32_t id = instrRulesCounter++;
     RequireAction("Engine::addInstrRule", id < EVENTID_VM_MASK, return VMError::INVALID_EVENTID);
     blockManager->clearCache(rule.affectedRange());
     switch(rule.getPosition()) {
         case InstPosition::PREINST:
-            instrRules.insert(instrRules.begin(), std::make_pair(id, (InstrRule::SharedPtr) rule));
+            if (top_list) {
+                instrRules.emplace_back(id, static_cast<InstrRule::SharedPtr>(rule));
+            } else {
+                instrRules.insert(instrRules.begin(), std::make_pair(id, static_cast<InstrRule::SharedPtr>(rule)));
+            }
             break;
         case InstPosition::POSTINST:
-            instrRules.push_back(std::make_pair(id, (InstrRule::SharedPtr) rule));
+            if (top_list) {
+                instrRules.insert(instrRules.begin(), std::make_pair(id, static_cast<InstrRule::SharedPtr>(rule)));
+            } else {
+                instrRules.emplace_back(id, static_cast<InstrRule::SharedPtr>(rule));
+            }
             break;
     }
     return id;

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -112,7 +112,7 @@ public:
     Engine(const std::string& cpu = "", const std::vector<std::string>& mattrs = {}, VMInstanceRef vminstance = nullptr);
 
     ~Engine();
-    
+
     /*! Obtain the current general purpose register state.
      *
      * @return A structure containing the GPR state.
@@ -159,7 +159,7 @@ public:
      */
     bool         addInstrumentedModuleFromAddr(rword addr);
 
-    /*! Adds all the executable memory maps to the instrumented range set. 
+    /*! Adds all the executable memory maps to the instrumented range set.
      * @return  True if at least one range was added to the instrumented ranges.
      */
     bool         instrumentAllExecutableMaps();
@@ -201,11 +201,12 @@ public:
     /*! Add a custom instrumentation rule to the engine. Requires internal headers
      *
      * @param[in] rule A custom instrumentation rule.
+     * @param[in] top_list Place the rule before all existing rules of its category
      *
      * @return The id of the registered instrumentation (or VMError::INVALID_EVENTID
      * in case of failure).
      */
-    uint32_t addInstrRule(InstrRule rule);
+    uint32_t addInstrRule(InstrRule rule, bool top_list);
 
     /*! Register a callback event for a specific VM event.
      *
@@ -231,7 +232,7 @@ public:
     void        deleteAllInstrumentations();
 
     /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
-     *  The validity of the returned pointer is only guaranteed until the end of the callback, else 
+     *  The validity of the returned pointer is only guaranteed until the end of the callback, else
      *  a deepcopy of the structure is required.
      *
      * @param[in] instMetadata Metadata to analyze.

--- a/src/Engine/VM.cpp
+++ b/src/Engine/VM.cpp
@@ -199,7 +199,7 @@ bool VM::callV(rword* retval, rword function, uint32_t argNum, va_list ap) {
 }
 
 uint32_t VM::addInstrRule(InstrRule rule) {
-    return engine->addInstrRule(rule);
+    return engine->addInstrRule(rule, false);
 }
 
 uint32_t VM::addMnemonicCB(const char* mnemonic, InstPosition pos, InstCallback cbk, void *data) {
@@ -341,7 +341,7 @@ bool VM::recordMemoryAccess(MemoryAccessType type) {
 #if defined(QBDI_ARCH_X86_64) || defined(QBDI_ARCH_X86)
     if(type & MEMORY_READ && !(memoryLoggingLevel & MEMORY_READ)) {
         memoryLoggingLevel |= MEMORY_READ;
-        addInstrRule(InstrRule(
+        engine->addInstrRule(InstrRule(
             DoesReadAccess(),
             {
                 GetReadAddress(Temp(0)),
@@ -351,11 +351,11 @@ bool VM::recordMemoryAccess(MemoryAccessType type) {
             },
             PREINST,
             false
-        ));
+        ), true); // force the rule to be the first of PREINST
     }
     if(type & MEMORY_WRITE && !(memoryLoggingLevel & MEMORY_WRITE)) {
         memoryLoggingLevel |= MEMORY_WRITE;
-        addInstrRule(InstrRule(
+        engine->addInstrRule(InstrRule(
             DoesWriteAccess(),
             {
                 GetWriteAddress(Temp(0)),
@@ -365,7 +365,7 @@ bool VM::recordMemoryAccess(MemoryAccessType type) {
             },
             POSTINST,
             false
-        ));
+        ), true); // force the rule to be the first of POSTINST
     }
     return true;
 #else

--- a/src/ExecBlock/ExecBlock.cpp
+++ b/src/ExecBlock/ExecBlock.cpp
@@ -350,7 +350,6 @@ uint16_t ExecBlock::newShadow(uint16_t tag) {
     if(tag != NO_REGISTRATION) {
         LogDebug("ExecBlock::newShadow", "Registering new tagged shadow %" PRIu16 " for instID %" PRIu16 " wih tag %" PRIu16, id, getNextInstID(), tag);
         shadowRegistry.push_back({
-            getNextSeqID(),
             getNextInstID(),
             tag,
             id
@@ -444,11 +443,22 @@ std::vector<ShadowInfo> ExecBlock::queryShadowByInst(uint16_t instID, uint16_t t
 std::vector<ShadowInfo> ExecBlock::queryShadowBySeq(uint16_t seqID, uint16_t tag) const {
     std::vector<ShadowInfo> result;
 
-    for(const auto& reg: shadowRegistry) {
-        if((seqID == ANY || reg.seqID  == seqID)  &&
-           (tag   == ANY || reg.tag   == tag)) {
-            result.push_back(reg);
+    if (seqID == ANY) {
+        for(const auto& reg: shadowRegistry) {
+            if(tag == ANY || reg.tag == tag) {
+                result.push_back(reg);
+            }
         }
+    } else {
+        uint16_t firstInstID = getSeqStart(seqID);
+        uint16_t lastInstID = getSeqEnd(seqID);
+        for(const auto& reg: shadowRegistry) {
+            if(firstInstID <= reg.instID && reg.instID <= lastInstID &&
+               (tag == ANY || reg.tag == tag)) {
+                result.push_back(reg);
+            }
+        }
+
     }
 
     return result;

--- a/src/ExecBlock/ExecBlock.h
+++ b/src/ExecBlock/ExecBlock.h
@@ -60,7 +60,6 @@ struct SeqWriteResult {
 };
 
 struct ShadowInfo {
-    uint16_t seqID;
     uint16_t instID;
     uint16_t tag;
     uint16_t shadowID;


### PR DESCRIPTION
Used the instID of ShadowInfo to search the shadow in a Sequence. The fix avoid to return no shadow when the sequence is a split of another.