### PR TITLE
Refactor cache InstAnalysis 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Next Version
 * Refactor ExecBlockManager to work with unaligned instruction on X86 and X86-64 (`#129 <https://github.com/QBDI/QBDI/pull/129>`_)
 * Drop early support for ARM. The support hasn't been tested since 0.6.2.
 * Rework cmake package export to import X86 and X86_64 version of QBDI in one CMake (`#146 <https://github.com/QBDI/QBDI/pull/146>`_ and `#132 <https://github.com/QBDI/QBDI/pull/132>`_)
+* Add VM::getCachedInstAnalysis to retrieve an InstAnalysis from an address. The address must be cached in the VM. (`#148 <https://github.com/QBDI/QBDI/pull/148>`_)
 
 Internal update:
 

--- a/docs/source/frida_bindings.rst
+++ b/docs/source/frida_bindings.rst
@@ -93,6 +93,8 @@ Analysis
 
 .. js:autofunction:: QBDI#getInstAnalysis
 
+.. js:autofunction:: QBDI#getCachedInstAnalysis
+
 .. js:autofunction:: QBDI#getInstMemoryAccess
 
 .. js:autofunction:: QBDI#getBBMemoryAccess

--- a/include/QBDI/VM.h
+++ b/include/QBDI/VM.h
@@ -354,9 +354,9 @@ public:
      */
     void        deleteAllInstrumentations();
 
-    /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
+    /*! Obtain the analysis of the current instruction. Analysis results are cached in the VM.
      *  The validity of the returned pointer is only guaranteed until the end of the callback, else
-     *  a deepcopy of the structure is required.
+     *  a deepcopy of the structure is required. This method must only be used in an InstCallback.
      *
      * @param[in] [type]         Properties to retrieve during analysis.
      *                           This argument is optional, defaulting to
@@ -364,7 +364,21 @@ public:
      *
      * @return A InstAnalysis structure containing the analysis result.
      */
-    const InstAnalysis* getInstAnalysis(AnalysisType type = ANALYSIS_INSTRUCTION | ANALYSIS_DISASSEMBLY);
+    const InstAnalysis* getInstAnalysis(AnalysisType type = ANALYSIS_INSTRUCTION | ANALYSIS_DISASSEMBLY) const;
+
+    /*! Obtain the analysis of a cached instruction. Analysis results are cached in the VM.
+     *  The validity of the returned pointer is only guaranteed until the end of the callback
+     *  or a call to a noconst method of the VM object.
+     *
+     * @param[in] address        The address of the instruction to analyse.
+     * @param[in] [type]         Properties to retrieve during analysis.
+     *                           This argument is optional, defaulting to
+     *                           QBDI::ANALYSIS_INSTRUCTION | QBDI::ANALYSIS_DISASSEMBLY.
+     *
+     * @return A InstAnalysis structure containing the analysis result.
+     *    null if the instruction isn't in the cache.
+     */
+    const InstAnalysis* getCachedInstAnalysis(rword address, AnalysisType type = ANALYSIS_INSTRUCTION | ANALYSIS_DISASSEMBLY) const;
 
     /*! Add instrumentation rules to log memory access using inline instrumentation and
      *  instruction shadows.

--- a/include/QBDI/VM_C.h
+++ b/include/QBDI/VM_C.h
@@ -328,16 +328,29 @@ QBDI_EXPORT bool qbdi_deleteInstrumentation(VMInstanceRef instance, uint32_t id)
  */
 QBDI_EXPORT void qbdi_deleteAllInstrumentations(VMInstanceRef instance);
 
- /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
+/*! Obtain the analysis of the current instruction. Analysis results are cached in the VM.
  *  The validity of the returned pointer is only guaranteed until the end of the callback, else
- *  a deepcopy of the structure is required.
+ *  a deepcopy of the structure is required. This method must only be used in an InstCallback.
  *
  * @param[in] instance     VM instance.
  * @param[in] type         Properties to retrieve during analysis.
  *
  * @return A InstAnalysis structure containing the analysis result.
  */
-QBDI_EXPORT const InstAnalysis* qbdi_getInstAnalysis(VMInstanceRef instance, AnalysisType type);
+QBDI_EXPORT const InstAnalysis* qbdi_getInstAnalysis(const VMInstanceRef instance, AnalysisType type);
+
+/*! Obtain the analysis of a cached instruction. Analysis results are cached in the VM.
+ *  The validity of the returned pointer is only guaranteed until the end of the callback
+ *  or a call to a noconst method of the VM instance.
+ *
+ * @param[in] instance     VM instance.
+ * @param[in] address      The address of the instruction to analyse.
+ * @param[in] type         Properties to retrieve during analysis.
+ *
+ * @return A InstAnalysis structure containing the analysis result.
+ *    null if the instruction isn't in the cache.
+ */
+QBDI_EXPORT const InstAnalysis* qbdi_getCachedInstAnalysis(const VMInstanceRef instance, rword address, AnalysisType type);
 
 /*! Add instrumentation rules to log memory access using inline instrumentation and
  *  instruction shadows.

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -389,7 +389,7 @@ bool Engine::precacheBasicBlock(rword pc) {
         // Commit the flush
         blockManager->flushCommit();
     }
-    if (blockManager->getProgrammedExecBlock(pc) != nullptr) {
+    if (blockManager->getExecBlock(pc) != nullptr) {
         // already in cache
         return false;
     }
@@ -553,6 +553,17 @@ void Engine::signalEvent(VMEvent event, rword currentPC, GPRState *gprState, FPR
             r.cbk(vminstance, &vmState, gprState, fprState, r.data);
         }
     }
+}
+
+const InstAnalysis* Engine::getInstAnalysis(rword address, AnalysisType type) const {
+    const ExecBlock* block = blockManager->getExecBlock(address);
+    if (block == nullptr) {
+        // not in cache
+        return nullptr;
+    }
+    uint16_t instID = block->getInstID(address);
+    RequireAction("Engine::getInstAnalysis", instID != NOT_FOUND, return nullptr);
+    return block->getInstAnalysis(instID, type);
 }
 
 bool Engine::deleteInstrumentation(uint32_t id) {

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -131,7 +131,7 @@ void Engine::init() {
     );
     // Allocate QBDI classes
     assembly = std::make_unique<Assembly>(*MCTX, std::move(MAB), *MCII, *processTarget, *MSTI);
-    blockManager = std::make_unique<ExecBlockManager>(*MCII, *MRI, *assembly, vminstance);
+    blockManager = std::make_unique<ExecBlockManager>(*assembly, vminstance);
     execBroker = std::make_unique<ExecBroker>(*assembly, vminstance);
 
     // Get default Patch rules for this architecture
@@ -345,7 +345,7 @@ std::vector<Patch> Engine::patch(rword start) {
             basicBlockEnd = true;
         }
 
-        basicBlock.push_back(patch);
+        basicBlock.push_back(std::move(patch));
     }
 
     return basicBlock;
@@ -585,10 +585,6 @@ void Engine::deleteAllInstrumentations() {
     vmCallbacks.clear();
     instrRulesCounter = 0;
     vmCallbacksCounter = 0;
-}
-
-const InstAnalysis* Engine::analyzeInstMetadata(const InstMetadata* instMetadata, AnalysisType type) {
-    return blockManager->analyzeInstMetadata(instMetadata, type);
 }
 
 void Engine::clearAllCache() {

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -29,7 +29,6 @@
 #endif
 
 #include "Callback.h"
-#include "InstAnalysis.h"
 #include "State.h"
 #include "Range.h"
 
@@ -248,17 +247,6 @@ public:
      *
      */
     void        deleteAllInstrumentations();
-
-    /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
-     *  The validity of the returned pointer is only guaranteed until the end of the callback, else
-     *  a deepcopy of the structure is required.
-     *
-     * @param[in] instMetadata Metadata to analyze.
-     * @param[in] type         Properties to retrieve during analysis.
-     *
-     * @return A InstAnalysis structure containing the analysis result.
-     */
-    const InstAnalysis* analyzeInstMetadata(const InstMetadata* instMetadata, AnalysisType type);
 
     /*! Expose current ExecBlock
      *

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -29,6 +29,7 @@
 #endif
 
 #include "Callback.h"
+#include "InstAnalysis.h"
 #include "State.h"
 #include "Range.h"
 
@@ -267,6 +268,17 @@ public:
      * @return True if basic block has been inserted in cache.
      */
     bool precacheBasicBlock(rword pc);
+
+    /*! Return an InstAnalysis for a cached instruction.
+     * The pointer may be invalid by any noconst method call.
+     *
+     * @param[in] address Start address of the instruction
+     * @param[in] type    type of the Analysis
+     *
+     * @return A pointer to the Analysis or a null pointer if the instruction isn't
+     *    in the cache.
+     */
+    const InstAnalysis* getInstAnalysis(rword address, AnalysisType type) const;
 
     /*! Clear a specific address range from the translation cache.
      *

--- a/src/Engine/VM.cpp
+++ b/src/Engine/VM.cpp
@@ -380,11 +380,15 @@ void VM::deleteAllInstrumentations() {
     memoryLoggingLevel = 0;
 }
 
-const InstAnalysis* VM::getInstAnalysis(AnalysisType type) {
+const InstAnalysis* VM::getInstAnalysis(AnalysisType type) const {
     const ExecBlock* curExecBlock = engine->getCurExecBlock();
     RequireAction("VM::getInstAnalysis", curExecBlock != nullptr, return nullptr);
     uint16_t curInstID = curExecBlock->getCurrentInstID();
     return curExecBlock->getInstAnalysis(curInstID, type);
+}
+
+const InstAnalysis* VM::getCachedInstAnalysis(rword address, AnalysisType type) const {
+    return engine->getInstAnalysis(address, type);
 }
 
 bool VM::recordMemoryAccess(MemoryAccessType type) {

--- a/src/Engine/VM.cpp
+++ b/src/Engine/VM.cpp
@@ -384,8 +384,7 @@ const InstAnalysis* VM::getInstAnalysis(AnalysisType type) {
     const ExecBlock* curExecBlock = engine->getCurExecBlock();
     RequireAction("VM::getInstAnalysis", curExecBlock != nullptr, return nullptr);
     uint16_t curInstID = curExecBlock->getCurrentInstID();
-    const InstMetadata* instMetadata = curExecBlock->getInstMetadata(curInstID);
-    return engine->analyzeInstMetadata(instMetadata, type);
+    return curExecBlock->getInstAnalysis(curInstID, type);
 }
 
 bool VM::recordMemoryAccess(MemoryAccessType type) {

--- a/src/Engine/VM_C.cpp
+++ b/src/Engine/VM_C.cpp
@@ -183,9 +183,14 @@ void qbdi_deleteAllInstrumentations(VMInstanceRef instance) {
     static_cast<VM*>(instance)->deleteAllInstrumentations();
 }
 
-const InstAnalysis* qbdi_getInstAnalysis(VMInstanceRef instance, AnalysisType type) {
+const InstAnalysis* qbdi_getInstAnalysis(const VMInstanceRef instance, AnalysisType type) {
     RequireAction("VM_C::getInstAnalysis", instance, return nullptr);
-    return static_cast<VM*>(instance)->getInstAnalysis(type);
+    return static_cast<const VM*>(instance)->getInstAnalysis(type);
+}
+
+const InstAnalysis* qbdi_getCachedInstAnalysis(const VMInstanceRef instance, rword address, AnalysisType type) {
+    RequireAction("VM_C::getCachedInstAnalysis", instance, return nullptr);
+    return static_cast<const VM*>(instance)->getCachedInstAnalysis(address, type);
 }
 
 bool qbdi_recordMemoryAccess(VMInstanceRef instance, MemoryAccessType type) {

--- a/src/ExecBlock/ExecBlock.cpp
+++ b/src/ExecBlock/ExecBlock.cpp
@@ -55,7 +55,7 @@ RelocatableInst::SharedPtrVec ExecBlock::execBlockPrologue = RelocatableInst::Sh
 RelocatableInst::SharedPtrVec ExecBlock::execBlockEpilogue = RelocatableInst::SharedPtrVec();
 void (*ExecBlock::runCodeBlockFct)(void*) = NULL;
 
-ExecBlock::ExecBlock(Assembly &assembly, VMInstanceRef vminstance) : vminstance(vminstance), assembly(assembly) {
+ExecBlock::ExecBlock(const Assembly &assembly, VMInstanceRef vminstance) : vminstance(vminstance), assembly(assembly) {
     // Allocate memory blocks
     std::error_code ec;
     // iOS now use 16k superpages, but as JIT mecanisms are totally differents

--- a/src/ExecBlock/ExecBlock.h
+++ b/src/ExecBlock/ExecBlock.h
@@ -254,6 +254,17 @@ public:
      */
     const llvm::MCInst* getOriginalMCInst(uint16_t instID) const;
 
+    /*! Obtain the analysis of an instruction metadata. Analysis results are cached in the InstAnalysis.
+     *  The validity of the returned pointer is only guaranteed until the end of the callback, else
+     *  a deepcopy of the structure is required.
+     *
+     * @param[in] instMetadata Metadata to analyze.
+     * @param[in] type         Properties to retrieve during analysis.
+     *
+     * @return A InstAnalysis structure containing the analysis result.
+     */
+    const InstAnalysis* getInstAnalysis(uint16_t instID, AnalysisType type) const;
+
     /*! Obtain the next sequence ID.
      *
      * @return The next sequence ID.

--- a/src/ExecBlock/ExecBlock.h
+++ b/src/ExecBlock/ExecBlock.h
@@ -93,7 +93,7 @@ private:
     llvm::sys::MemoryBlock            codeBlock;
     llvm::sys::MemoryBlock            dataBlock;
     std::unique_ptr<memory_ostream>   codeStream;
-    Assembly&                         assembly;
+    const Assembly&                   assembly;
     Context*                          context;
     rword*                            shadows;
     std::vector<ShadowInfo>           shadowRegistry;
@@ -132,7 +132,7 @@ public:
      * @param[in] assembly    Assembly used to assemble instructions in the ExecBlock.
      * @param[in] vminstance  Pointer to public engine interface
      */
-    ExecBlock(Assembly& assembly, VMInstanceRef vminstance = nullptr);
+    ExecBlock(const Assembly& assembly, VMInstanceRef vminstance = nullptr);
 
     ~ExecBlock();
 

--- a/src/ExecBlock/ExecBlockManager.cpp
+++ b/src/ExecBlock/ExecBlockManager.cpp
@@ -124,6 +124,26 @@ ExecBlock* ExecBlockManager::getProgrammedExecBlock(rword address) {
     return nullptr;
 }
 
+const ExecBlock* ExecBlockManager::getExecBlock(rword address) const {
+    LogDebug("ExecBlockManager::getExecBlock", "Looking up address %" PRIRWORD, address);
+
+    size_t r = searchRegion(address);
+
+    if(r < regions.size() && regions[r].covered.contains(address)) {
+        const ExecRegion& region = regions[r];
+
+        // Attempting instCache resolution
+        const std::map<rword, InstLoc>::const_iterator instLoc = region.instCache.find(address);
+        if(instLoc != region.instCache.end()) {
+            LogDebug("ExecBlockManager::getExecBlock", "Found address 0x%" PRIRWORD " in ExecBlock %p",
+                     address, region.blocks[seqLoc->second.blockIdx].get());
+            return region.blocks[instLoc->second.blockIdx].get();
+        }
+    }
+    LogDebug("ExecBlockManager::getExecBlock", "Cache miss for address 0x%" PRIRWORD, address);
+    return nullptr;
+}
+
 const SeqLoc* ExecBlockManager::getSeqLoc(rword address) const {
     size_t r = searchRegion(address);
     if(r < regions.size() && regions[r].covered.contains(address)) {

--- a/src/ExecBlock/ExecBlockManager.cpp
+++ b/src/ExecBlock/ExecBlockManager.cpp
@@ -19,31 +19,16 @@
 #include <bitset>
 #include <cstdint>
 
-#include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCInstrDesc.h"
-
 #include "ExecBlock/ExecBlock.h"
 #include "ExecBlock/ExecBlockManager.h"
-#include "Patch/InstInfo.h"
 #include "Patch/PatchRule.h"
-#include "Patch/RegisterSize.h"
-#include "Utility/Assembly.h"
 #include "Utility/LogSys.h"
 
-#include "Platform.h"
 #include "State.h"
-
-#ifndef QBDI_PLATFORM_WINDOWS
-#if defined(QBDI_PLATFORM_LINUX) && !defined(__USE_GNU)
-#define __USE_GNU
-#endif
-#include <dlfcn.h>
-#endif
 
 namespace QBDI {
 
-ExecBlockManager::ExecBlockManager(llvm::MCInstrInfo& MCII, llvm::MCRegisterInfo& MRI, Assembly& assembly, VMInstanceRef vminstance) :
+ExecBlockManager::ExecBlockManager(const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI, const Assembly& assembly, VMInstanceRef vminstance) :
    total_translated_size(1), total_translation_size(1), vminstance(vminstance), MCII(MCII), MRI(MRI), assembly(assembly) {
 }
 
@@ -460,200 +445,6 @@ void ExecBlockManager::updateRegionStat(size_t r, rword translated) {
     }
 }
 
-static void analyseRegister(OperandAnalysis& opa, unsigned int regNo, const llvm::MCRegisterInfo& MRI) {
-    opa.regName = MRI.getName(regNo);
-    opa.value = regNo;
-    opa.size = 0;
-    opa.regOff = 0;
-    opa.regCtxIdx = 0;
-    opa.type = OPERAND_INVALID;
-    if (regNo == /* llvm::X86|ARM::NoRegister */ 0)
-        return;
-    // try to match register in our GPR context
-    for (uint16_t j = 0; j < NUM_GPR; j++) {
-        if (MRI.isSubRegisterEq(GPR_ID[j], regNo)) {
-            if (GPR_ID[j] != regNo) {
-                unsigned int subregidx = MRI.getSubRegIndex(GPR_ID[j], regNo);
-                opa.regOff = MRI.getSubRegIdxOffset(subregidx);
-            }
-            opa.regCtxIdx = j;
-            opa.size = getRegisterSize(regNo);
-            opa.type = OPERAND_GPR;
-            return;
-        }
-    }
-}
-
-static void tryMergeCurrentRegister(InstAnalysis* instAnalysis) {
-    OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands - 1];
-    if (opa.type != QBDI::OPERAND_GPR) {
-        return;
-    }
-    for (uint16_t j = 0; j < instAnalysis->numOperands - 1; j++) {
-        OperandAnalysis& pop = instAnalysis->operands[j];
-        if (pop.type != opa.type || pop.flag != opa.flag) {
-            continue;
-        }
-        if (pop.regCtxIdx == opa.regCtxIdx &&
-                pop.size == opa.size &&
-                pop.regOff == opa.regOff) {
-            // merge current one into previous one
-            pop.regAccess |= opa.regAccess;
-            memset(&opa, 0, sizeof(OperandAnalysis));
-            instAnalysis->numOperands--;
-            break;
-        }
-    }
-}
-
-static void analyseImplicitRegisters(InstAnalysis* instAnalysis, const uint16_t* implicitRegs, std::vector<unsigned int>& skipRegs,
-                                     RegisterAccessType type, const llvm::MCRegisterInfo& MRI) {
-    if (!implicitRegs) {
-        return;
-    }
-    // Iteration style copied from LLVM code
-    for (; *implicitRegs; ++implicitRegs) {
-        OperandAnalysis topa;
-        llvm::MCPhysReg regNo = *implicitRegs;
-        // skip register if in blacklist
-        if(std::find_if(skipRegs.begin(), skipRegs.end(),
-                [&regNo, &MRI](const unsigned int skipRegNo) {
-                    return MRI.isSubRegisterEq(skipRegNo, regNo);
-                }) != skipRegs.end()) {
-            continue;
-        }
-        analyseRegister(topa, *implicitRegs, MRI);
-        // we found a GPR (as size is only known for GPR)
-        // TODO: add support for more registers
-        if (topa.size != 0 && topa.type != OPERAND_INVALID) {
-            // fill a new operand analysis
-            OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands];
-            opa = topa;
-            opa.regAccess = type;
-            instAnalysis->numOperands++;
-            // try to merge with a previous one
-            tryMergeCurrentRegister(instAnalysis);
-        }
-    }
-}
-
-static void analyseOperands(InstAnalysis* instAnalysis, const llvm::MCInst& inst, const llvm::MCInstrDesc& desc, const llvm::MCRegisterInfo& MRI) {
-    if (!instAnalysis) {
-        // no instruction analysis
-        return;
-    }
-    instAnalysis->numOperands = 0; // updated later because we could skip some
-    instAnalysis->operands = NULL;
-    // Analysis of instruction operands
-    uint8_t numOperands = inst.getNumOperands();
-    uint8_t numOperandsMax = numOperands + desc.getNumImplicitDefs() + desc.getNumImplicitUses();
-    if (numOperandsMax == 0) {
-        // no operand to analyse
-        return;
-    }
-    instAnalysis->operands = new OperandAnalysis[numOperandsMax]();
-    // find written registers
-    std::bitset<16> regWrites;
-    for (unsigned i = 0,
-            e = desc.isVariadic() ? inst.getNumOperands() : desc.getNumDefs();
-            i != e; ++i) {
-        const llvm::MCOperand& op = inst.getOperand(i);
-        if (op.isReg()) {
-            regWrites.set(i, true);
-        }
-    }
-    std::vector<unsigned int> skipRegs;
-    // for each instruction operands
-    for (uint8_t i = 0; i < numOperands; i++) {
-        const llvm::MCOperand& op = inst.getOperand(i);
-        const llvm::MCOperandInfo& opdesc = desc.OpInfo[i];
-        // fill a new operand analysis
-        OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands];
-        // reinitialise the opa if a previous iteration has write some value
-        opa = OperandAnalysis();
-        if (!op.isValid()) {
-            continue;
-        }
-        if (op.isReg()) {
-            unsigned int regNo = op.getReg();
-            // validate that this is really a register operand, not
-            // something else (memory access)
-            if (regNo == 0)
-                continue;
-            // fill the operand analysis
-            analyseRegister(opa, regNo, MRI);
-            // we have'nt found a GPR (as size is only known for GPR)
-            if (opa.size == 0 || opa.type == OPERAND_INVALID) {
-                // TODO: add support for more registers
-                continue;
-            }
-            switch (opdesc.OperandType) {
-                case llvm::MCOI::OPERAND_REGISTER:
-                    break;
-                case llvm::MCOI::OPERAND_MEMORY:
-                    opa.flag |= OPERANDFLAG_ADDR;
-                    break;
-                case llvm::MCOI::OPERAND_UNKNOWN:
-                    opa.flag |= OPERANDFLAG_UNDEFINED_EFFECT;
-                    break;
-                default:
-                    LogWarning("ExecBlockManager::analyseOperands",
-                            "Not supported operandType %d for register operand", opdesc.OperandType);
-                    continue;
-            }
-            opa.regAccess = regWrites.test(i) ? REGISTER_WRITE : REGISTER_READ;
-            instAnalysis->numOperands++;
-            // try to merge with a previous one
-            tryMergeCurrentRegister(instAnalysis);
-        } else if (op.isImm()) {
-            // fill the operand analysis
-            switch (opdesc.OperandType) {
-                case llvm::MCOI::OPERAND_IMMEDIATE:
-                    opa.size = getImmediateSize(&inst, &desc);
-                    break;
-                case llvm::MCOI::OPERAND_MEMORY:
-                    opa.flag |= OPERANDFLAG_ADDR;
-                    opa.size = sizeof(rword);
-                    break;
-                case llvm::MCOI::OPERAND_PCREL:
-                    opa.size = getImmediateSize(&inst, &desc);
-                    opa.flag |= OPERANDFLAG_PCREL;
-                    break;
-                case llvm::MCOI::OPERAND_UNKNOWN:
-                    opa.flag |= OPERANDFLAG_UNDEFINED_EFFECT;
-                    opa.size = sizeof(rword);
-                    break;
-                default:
-                    LogWarning("ExecBlockManager::analyseOperands",
-                            "Not supported operandType %d for immediate operand", opdesc.OperandType);
-                    continue;
-            }
-            if (opdesc.isPredicate()) {
-                opa.type = OPERAND_PRED;
-            } else {
-                opa.type = OPERAND_IMM;
-            }
-            opa.value = static_cast<rword>(op.getImm());
-            instAnalysis->numOperands++;
-        }
-    }
-
-    // analyse implicit registers (R/W)
-    analyseImplicitRegisters(instAnalysis, desc.getImplicitDefs(), skipRegs, REGISTER_WRITE, MRI);
-    analyseImplicitRegisters(instAnalysis, desc.getImplicitUses(), skipRegs, REGISTER_READ, MRI);
-}
-
-
-void InstAnalysisDestructor::operator()(InstAnalysis* ptr) const {
-    if (ptr == nullptr) {
-        return;
-    }
-    delete[] ptr->operands;
-    delete[] ptr->disassembly;
-    delete ptr;
-}
-
-
 const InstAnalysis* ExecBlockManager::analyzeInstMetadata(const InstMetadata* instMetadata, AnalysisType type) {
     InstAnalysis* instAnalysis = nullptr;
     RequireAction("Engine::analyzeInstMetadata", instMetadata, return nullptr);
@@ -676,79 +467,19 @@ const InstAnalysis* ExecBlockManager::analyzeInstMetadata(const InstMetadata* in
     if (instAnalysis != nullptr) {
         return instAnalysis;
     }
-    // Cache miss
-    const llvm::MCInst &inst = instMetadata->inst;
-    const llvm::MCInstrDesc &desc = MCII.get(inst.getOpcode());
 
-
-    instAnalysis = new InstAnalysis;
-    // set all values to NULL/0/false
-    memset(instAnalysis, 0, sizeof(InstAnalysis));
-
-    instAnalysis->analysisType      = type;
-
-    if (type & ANALYSIS_DISASSEMBLY) {
-        int len = 0;
-        std::string buffer;
-        llvm::raw_string_ostream bufferOs(buffer);
-        assembly.printDisasm(inst, instMetadata->address, bufferOs);
-        bufferOs.flush();
-        len = buffer.size() + 1;
-        instAnalysis->disassembly = new char[len];
-        strncpy(instAnalysis->disassembly, buffer.c_str(), len);
-        buffer.clear();
-    }
-
-    if (type & ANALYSIS_INSTRUCTION) {
-        instAnalysis->address           = instMetadata->address;
-        instAnalysis->instSize          = instMetadata->instSize;
-        instAnalysis->affectControlFlow = instMetadata->modifyPC;
-        instAnalysis->isBranch          = desc.isBranch();
-        instAnalysis->isCall            = desc.isCall();
-        instAnalysis->isReturn          = desc.isReturn();
-        instAnalysis->isCompare         = desc.isCompare();
-        instAnalysis->isPredicable      = desc.isPredicable();
-        instAnalysis->mayLoad           = desc.mayLoad();
-        instAnalysis->mayStore          = desc.mayStore();
-        instAnalysis->mnemonic          = MCII.getName(inst.getOpcode()).data();
-    }
-
-    if (type & ANALYSIS_OPERANDS) {
-        // analyse operands (immediates / registers)
-        analyseOperands(instAnalysis, inst, desc, MRI);
-    }
-
-    if (type & ANALYSIS_SYMBOL) {
-        // find nearest symbol (if any)
-#ifndef QBDI_PLATFORM_WINDOWS
-        Dl_info info;
-        const char* ptr;
-
-        int ret = dladdr((void*) instAnalysis->address, &info);
-        if (ret != 0) {
-            if (info.dli_sname) {
-                instAnalysis->symbol = info.dli_sname;
-                instAnalysis->symbolOffset = instAnalysis->address - (rword) info.dli_saddr;
-            }
-            if (info.dli_fname) {
-                // dirty basename, but thead safe
-                if((ptr = strrchr(info.dli_fname, '/')) != nullptr) {
-                    instAnalysis->module = ptr + 1;
-                }
-            }
-        }
-#endif
-    }
+    InstAnalysisPtr ana = analyzeInstMetadata_uncached(*instMetadata, type, MCII, MRI, assembly);
+    instAnalysis = ana.get();
 
     // If its part of a region, put in in the region cache
     if(r < regions.size() && regions[r].covered.contains(instMetadata->address)) {
         LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " cached in region %zu", instMetadata->address, r);
-        regions[r].analysisCache[instMetadata->address] = InstAnalysisPtr(instAnalysis);
+        regions[r].analysisCache[instMetadata->address] = std::move(ana);
     }
     // Put it in the global cache. Should never happen under normal usage
     else {
         LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " cached in global cache", instMetadata->address);
-        analysisCache[instMetadata->address] = InstAnalysisPtr(instAnalysis);
+        analysisCache[instMetadata->address] = std::move(ana);
     }
     return instAnalysis;
 }

--- a/src/ExecBlock/ExecBlockManager.cpp
+++ b/src/ExecBlock/ExecBlockManager.cpp
@@ -16,20 +16,19 @@
  * limitations under the License.
  */
 #include <algorithm>
-#include <bitset>
 #include <cstdint>
 
 #include "ExecBlock/ExecBlock.h"
 #include "ExecBlock/ExecBlockManager.h"
-#include "Patch/PatchRule.h"
+#include "Patch/Patch.h"
 #include "Utility/LogSys.h"
 
 #include "State.h"
 
 namespace QBDI {
 
-ExecBlockManager::ExecBlockManager(const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI, const Assembly& assembly, VMInstanceRef vminstance) :
-   total_translated_size(1), total_translation_size(1), vminstance(vminstance), MCII(MCII), MRI(MRI), assembly(assembly) {
+ExecBlockManager::ExecBlockManager(const Assembly& assembly, VMInstanceRef vminstance) :
+   total_translated_size(1), total_translation_size(1), vminstance(vminstance), assembly(assembly) {
 }
 
 ExecBlockManager::~ExecBlockManager() {
@@ -284,10 +283,6 @@ void ExecBlockManager::mergeRegion(size_t i) {
     // ExecBlock
     std::move(regions[i+1].blocks.begin(), regions[i+1].blocks.end(),
               std::back_inserter(regions[i].blocks));
-    // InstAnalysis
-    std::move(regions[i+1].analysisCache.begin(), regions[i+1].analysisCache.end(),
-              std::insert_iterator<std::map<rword, InstAnalysisPtr>>(regions[i].analysisCache,
-                                                                     regions[i].analysisCache.end()));
     // flush
     regions[i].toFlush |= regions[i+1].toFlush;
 
@@ -445,46 +440,6 @@ void ExecBlockManager::updateRegionStat(size_t r, rword translated) {
     }
 }
 
-const InstAnalysis* ExecBlockManager::analyzeInstMetadata(const InstMetadata* instMetadata, AnalysisType type) {
-    InstAnalysis* instAnalysis = nullptr;
-    RequireAction("Engine::analyzeInstMetadata", instMetadata, return nullptr);
-
-    size_t r = searchRegion(instMetadata->address);
-
-    // Attempt to locate it in the sequenceCache
-    if(r < regions.size() && regions[r].covered.contains(instMetadata->address) &&
-       regions[r].analysisCache.count(instMetadata->address) == 1) {
-        LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " found in sequenceCache of region %zu", instMetadata->address, r);
-        instAnalysis = regions[r].analysisCache[instMetadata->address].get();
-    }
-    if (instAnalysis != nullptr &&
-        ((instAnalysis->analysisType & type) != type)) {
-        LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " need to be rebuilt", instMetadata->address);
-        // Free current cache because we want more data
-        instAnalysis = nullptr;
-    }
-    // We have a usable cached analysis
-    if (instAnalysis != nullptr) {
-        return instAnalysis;
-    }
-
-    InstAnalysisPtr ana = analyzeInstMetadata_uncached(*instMetadata, type, MCII, MRI, assembly);
-    instAnalysis = ana.get();
-
-    // If its part of a region, put in in the region cache
-    if(r < regions.size() && regions[r].covered.contains(instMetadata->address)) {
-        LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " cached in region %zu", instMetadata->address, r);
-        regions[r].analysisCache[instMetadata->address] = std::move(ana);
-    }
-    // Put it in the global cache. Should never happen under normal usage
-    else {
-        LogDebug("ExecBlockManager::analyzeInstMetadata", "Analysis of instruction 0x%" PRIRWORD " cached in global cache", instMetadata->address);
-        analysisCache[instMetadata->address] = std::move(ana);
-    }
-    return instAnalysis;
-}
-
-
 void ExecBlockManager::clearCache(RangeSet<rword> rangeSet) {
     const std::vector<Range<rword>>& ranges = rangeSet.getRanges();
     for(Range<rword> r: ranges) {
@@ -506,7 +461,6 @@ void ExecBlockManager::flushCommit() {
                              r.covered.start(), r.covered.end());
                 return r.toFlush;
             }), regions.end());
-        analysisCache.clear();
         needFlush = false;
     }
 }
@@ -526,7 +480,6 @@ void ExecBlockManager::clearCache(bool flushNow) {
     LogDebug("ExecBlockManager::clearCache", "Erasing all cache");
     if (flushNow) {
         regions.clear();
-        analysisCache.clear();
         total_translated_size = 1;
         total_translation_size = 1;
         needFlush = false;

--- a/src/ExecBlock/ExecBlockManager.h
+++ b/src/ExecBlock/ExecBlockManager.h
@@ -102,6 +102,8 @@ class ExecBlockManager {
 
     ExecBlock* getProgrammedExecBlock(rword address);
 
+    const ExecBlock* getExecBlock(rword address) const;
+
     const SeqLoc* getSeqLoc(rword address) const;
 
     void writeBasicBlock(const std::vector<Patch>& basicBlock);

--- a/src/ExecBlock/ExecBlockManager.h
+++ b/src/ExecBlock/ExecBlockManager.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <vector>
 
+#include "Utility/InstAnalysis_prive.h"
+
 #include "Callback.h"
 #include "InstAnalysis.h"
 #include "Range.h"
@@ -39,10 +41,6 @@ class ExecBlock;
 class InstMetadata;
 class Patch;
 class RelocatableInst;
-
-struct InstAnalysisDestructor {
-  void operator()(InstAnalysis* ptr) const;
-};
 
 
 struct InstLoc {
@@ -85,10 +83,10 @@ private:
     rword                              total_translation_size;
     bool                               needFlush;
 
-    VMInstanceRef              vminstance;
-    llvm::MCInstrInfo&         MCII;
-    llvm::MCRegisterInfo&      MRI;
-    Assembly&                  assembly;
+    VMInstanceRef                    vminstance;
+    const llvm::MCInstrInfo&         MCII;
+    const llvm::MCRegisterInfo&      MRI;
+    const Assembly&                  assembly;
 
     size_t searchRegion(rword start) const;
 
@@ -102,7 +100,7 @@ private:
 
 public:
 
-    ExecBlockManager(llvm::MCInstrInfo& MCII, llvm::MCRegisterInfo& MRI, Assembly& assembly, VMInstanceRef vminstance = nullptr);
+    ExecBlockManager(const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI, const Assembly& assembly, VMInstanceRef vminstance = nullptr);
 
     ~ExecBlockManager();
 

--- a/src/ExecBlock/ExecBlockManager.h
+++ b/src/ExecBlock/ExecBlockManager.h
@@ -22,10 +22,7 @@
 #include <map>
 #include <vector>
 
-#include "Utility/InstAnalysis_prive.h"
-
 #include "Callback.h"
-#include "InstAnalysis.h"
 #include "Range.h"
 #include "State.h"
 
@@ -58,15 +55,12 @@ struct SeqLoc {
 };
 
 struct ExecRegion {
-    using InstAnalysisPtr = std::unique_ptr<InstAnalysis, InstAnalysisDestructor>;
-
     Range<rword>                             covered;
     unsigned                                 translated;
     unsigned                                 available;
     std::vector<std::unique_ptr<ExecBlock>>  blocks;
     std::map<rword, SeqLoc>                  sequenceCache;
     std::map<rword, InstLoc>                 instCache;
-    std::map<rword, InstAnalysisPtr>         analysisCache;
     bool                                     toFlush = false;
 
     ExecRegion(ExecRegion&&) = default;
@@ -74,18 +68,14 @@ struct ExecRegion {
 };
 
 class ExecBlockManager {
-private:
-    using InstAnalysisPtr = std::unique_ptr<InstAnalysis, InstAnalysisDestructor>;
+    private:
 
     std::vector<ExecRegion>            regions;
-    std::map<rword, InstAnalysisPtr>   analysisCache;
     rword                              total_translated_size;
     rword                              total_translation_size;
     bool                               needFlush;
 
     VMInstanceRef                    vminstance;
-    const llvm::MCInstrInfo&         MCII;
-    const llvm::MCRegisterInfo&      MRI;
     const Assembly&                  assembly;
 
     size_t searchRegion(rword start) const;
@@ -98,9 +88,9 @@ private:
 
     float getExpansionRatio() const;
 
-public:
+    public:
 
-    ExecBlockManager(const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI, const Assembly& assembly, VMInstanceRef vminstance = nullptr);
+    ExecBlockManager(const Assembly& assembly, VMInstanceRef vminstance = nullptr);
 
     ~ExecBlockManager();
 
@@ -115,8 +105,6 @@ public:
     const SeqLoc* getSeqLoc(rword address) const;
 
     void writeBasicBlock(const std::vector<Patch>& basicBlock);
-
-    const InstAnalysis* analyzeInstMetadata(const InstMetadata* instMetadata, AnalysisType type);
 
     bool isFlushPending() { return needFlush; }
 

--- a/src/ExecBroker/ExecBroker.cpp
+++ b/src/ExecBroker/ExecBroker.cpp
@@ -20,7 +20,7 @@
 
 namespace QBDI {
 
-ExecBroker::ExecBroker(Assembly& assembly, VMInstanceRef vminstance) :
+ExecBroker::ExecBroker(const Assembly& assembly, VMInstanceRef vminstance) :
     transferBlock(assembly, vminstance) {
     pageSize =
       llvm::expectedToOptional(llvm::sys::Process::getPageSize()).getValueOr(4096);

--- a/src/ExecBroker/ExecBroker.h
+++ b/src/ExecBroker/ExecBroker.h
@@ -45,7 +45,7 @@ private:
 
 public:
 
-    ExecBroker(Assembly& assembly, VMInstanceRef vminstance = nullptr);
+    ExecBroker(const Assembly& assembly, VMInstanceRef vminstance = nullptr);
 
     void changeVMInstanceRef(VMInstanceRef vminstance);
 

--- a/src/Patch/InstMetadata.h
+++ b/src/Patch/InstMetadata.h
@@ -19,6 +19,9 @@
 #define INSTMETADATA_H
 
 #include "llvm/MC/MCInst.h"
+
+#include "Utility/InstAnalysis_prive.h"
+
 #include "State.h"
 
 namespace QBDI {
@@ -31,9 +34,14 @@ public:
     uint32_t patchSize;
     bool modifyPC;
     bool merge;
+    mutable InstAnalysisPtr analysis;
 
     inline rword endAddress() const {
         return address + instSize;
+    }
+
+    inline InstMetadata lightCopy() const {
+        return {inst, address, instSize, patchSize, modifyPC, merge, nullptr};
     }
 };
 

--- a/src/Utility/Assembly.h
+++ b/src/Utility/Assembly.h
@@ -67,6 +67,10 @@ public:
     void printDisasm(const llvm::MCInst &inst, uint64_t address, llvm::raw_ostream &out = llvm::errs()) const;
 
     const char* getRegisterName(unsigned int id) const {return MRI.getName(id); }
+
+    inline const llvm::MCInstrInfo& getMCII() const { return MCII; }
+
+    inline const llvm::MCRegisterInfo& getMRI() const { return MRI; }
 };
 
 }

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -1,13 +1,14 @@
 # Add QBDI target
 set(SOURCES
-    "${CMAKE_CURRENT_LIST_DIR}/memory_ostream.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/Assembly.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/InstAnalysis.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/LogSys.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/Memory.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/Memory_${QBDI_PLATFORM}.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/System.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/LogSys.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/Version.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/String.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/System.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/Version.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/memory_ostream.cpp"
     )
 
 if(QBDI_PLATFORM_IOS)

--- a/src/Utility/InstAnalysis.cpp
+++ b/src/Utility/InstAnalysis.cpp
@@ -1,0 +1,318 @@
+/*
+ * This file is part of QBDI.
+ *
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <bitset>
+
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+
+#include "ExecBlock/Context.h"
+#include "Patch/InstInfo.h"
+#include "Patch/InstMetadata.h"
+#include "Patch/RegisterSize.h"
+#include "Utility/Assembly.h"
+#include "Utility/InstAnalysis_prive.h"
+#include "Utility/LogSys.h"
+
+#include "Platform.h"
+#include "State.h"
+
+#ifndef QBDI_PLATFORM_WINDOWS
+#if defined(QBDI_PLATFORM_LINUX) && !defined(__USE_GNU)
+#define __USE_GNU
+#endif
+#include <dlfcn.h>
+#endif
+
+namespace QBDI {
+
+namespace {
+
+void analyseRegister(OperandAnalysis& opa, unsigned int regNo, const llvm::MCRegisterInfo& MRI) {
+    opa.regName = MRI.getName(regNo);
+    opa.value = regNo;
+    opa.size = 0;
+    opa.regOff = 0;
+    opa.regCtxIdx = 0;
+    opa.type = OPERAND_INVALID;
+    if (regNo == /* llvm::X86|ARM::NoRegister */ 0) {
+        return;
+    }
+    // try to match register in our GPR context
+    for (uint16_t j = 0; j < NUM_GPR; j++) {
+        if (MRI.isSubRegisterEq(GPR_ID[j], regNo)) {
+            if (GPR_ID[j] != regNo) {
+                unsigned int subregidx = MRI.getSubRegIndex(GPR_ID[j], regNo);
+                opa.regOff = MRI.getSubRegIdxOffset(subregidx);
+            }
+            opa.regCtxIdx = j;
+            opa.size = getRegisterSize(regNo);
+            opa.type = OPERAND_GPR;
+            return;
+        }
+    }
+}
+
+void tryMergeCurrentRegister(InstAnalysis* instAnalysis) {
+    OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands - 1];
+    if (opa.type != QBDI::OPERAND_GPR) {
+        return;
+    }
+    for (uint16_t j = 0; j < instAnalysis->numOperands - 1; j++) {
+        OperandAnalysis& pop = instAnalysis->operands[j];
+        if (pop.type != opa.type || pop.flag != opa.flag) {
+            continue;
+        }
+        if (pop.regCtxIdx == opa.regCtxIdx &&
+                pop.size == opa.size &&
+                pop.regOff == opa.regOff) {
+            // merge current one into previous one
+            pop.regAccess |= opa.regAccess;
+            memset(&opa, 0, sizeof(OperandAnalysis));
+            instAnalysis->numOperands--;
+            break;
+        }
+    }
+}
+
+void analyseImplicitRegisters(InstAnalysis* instAnalysis, const uint16_t* implicitRegs, std::vector<unsigned int>& skipRegs,
+                              RegisterAccessType type, const llvm::MCRegisterInfo& MRI) {
+    if (!implicitRegs) {
+        return;
+    }
+    // Iteration style copied from LLVM code
+    for (; *implicitRegs; ++implicitRegs) {
+        OperandAnalysis topa;
+        llvm::MCPhysReg regNo = *implicitRegs;
+        // skip register if in blacklist
+        if(std::find_if(skipRegs.begin(), skipRegs.end(),
+                [&regNo, &MRI](const unsigned int skipRegNo) {
+                    return MRI.isSubRegisterEq(skipRegNo, regNo);
+                }) != skipRegs.end()) {
+            continue;
+        }
+        analyseRegister(topa, *implicitRegs, MRI);
+        // we found a GPR (as size is only known for GPR)
+        // TODO: add support for more registers
+        if (topa.size != 0 && topa.type != OPERAND_INVALID) {
+            // fill a new operand analysis
+            OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands];
+            opa = topa;
+            opa.regAccess = type;
+            instAnalysis->numOperands++;
+            // try to merge with a previous one
+            tryMergeCurrentRegister(instAnalysis);
+        }
+    }
+}
+
+void analyseOperands(InstAnalysis* instAnalysis, const llvm::MCInst& inst, const llvm::MCInstrDesc& desc, const llvm::MCRegisterInfo& MRI) {
+    if (!instAnalysis) {
+        // no instruction analysis
+        return;
+    }
+    instAnalysis->numOperands = 0; // updated later because we could skip some
+    instAnalysis->operands = NULL;
+    // Analysis of instruction operands
+    uint8_t numOperands = inst.getNumOperands();
+    uint8_t numOperandsMax = numOperands + desc.getNumImplicitDefs() + desc.getNumImplicitUses();
+    if (numOperandsMax == 0) {
+        // no operand to analyse
+        return;
+    }
+    instAnalysis->operands = new OperandAnalysis[numOperandsMax]();
+    // find written registers
+    std::bitset<16> regWrites;
+    for (unsigned i = 0,
+            e = desc.isVariadic() ? inst.getNumOperands() : desc.getNumDefs();
+            i != e; ++i) {
+        const llvm::MCOperand& op = inst.getOperand(i);
+        if (op.isReg()) {
+            regWrites.set(i, true);
+        }
+    }
+    std::vector<unsigned int> skipRegs;
+    // for each instruction operands
+    for (uint8_t i = 0; i < numOperands; i++) {
+        const llvm::MCOperand& op = inst.getOperand(i);
+        const llvm::MCOperandInfo& opdesc = desc.OpInfo[i];
+        // fill a new operand analysis
+        OperandAnalysis& opa = instAnalysis->operands[instAnalysis->numOperands];
+        // reinitialise the opa if a previous iteration has write some value
+        opa = OperandAnalysis();
+        if (!op.isValid()) {
+            continue;
+        }
+        if (op.isReg()) {
+            unsigned int regNo = op.getReg();
+            // validate that this is really a register operand, not
+            // something else (memory access)
+            if (regNo == 0) {
+                continue;
+            }
+            // fill the operand analysis
+            analyseRegister(opa, regNo, MRI);
+            // we have'nt found a GPR (as size is only known for GPR)
+            if (opa.size == 0 || opa.type == OPERAND_INVALID) {
+                // TODO: add support for more registers
+                continue;
+            }
+            switch (opdesc.OperandType) {
+                case llvm::MCOI::OPERAND_REGISTER:
+                    break;
+                case llvm::MCOI::OPERAND_MEMORY:
+                    opa.flag |= OPERANDFLAG_ADDR;
+                    break;
+                case llvm::MCOI::OPERAND_UNKNOWN:
+                    opa.flag |= OPERANDFLAG_UNDEFINED_EFFECT;
+                    break;
+                default:
+                    LogWarning("ExecBlockManager::analyseOperands",
+                            "Not supported operandType %d for register operand", opdesc.OperandType);
+                    continue;
+            }
+            opa.regAccess = regWrites.test(i) ? REGISTER_WRITE : REGISTER_READ;
+            instAnalysis->numOperands++;
+            // try to merge with a previous one
+            tryMergeCurrentRegister(instAnalysis);
+        } else if (op.isImm()) {
+            // fill the operand analysis
+            switch (opdesc.OperandType) {
+                case llvm::MCOI::OPERAND_IMMEDIATE:
+                    opa.size = getImmediateSize(&inst, &desc);
+                    break;
+                case llvm::MCOI::OPERAND_MEMORY:
+                    opa.flag |= OPERANDFLAG_ADDR;
+                    opa.size = sizeof(rword);
+                    break;
+                case llvm::MCOI::OPERAND_PCREL:
+                    opa.size = getImmediateSize(&inst, &desc);
+                    opa.flag |= OPERANDFLAG_PCREL;
+                    break;
+                case llvm::MCOI::OPERAND_UNKNOWN:
+                    opa.flag |= OPERANDFLAG_UNDEFINED_EFFECT;
+                    opa.size = sizeof(rword);
+                    break;
+                default:
+                    LogWarning("ExecBlockManager::analyseOperands",
+                            "Not supported operandType %d for immediate operand", opdesc.OperandType);
+                    continue;
+            }
+            if (opdesc.isPredicate()) {
+                opa.type = OPERAND_PRED;
+            } else {
+                opa.type = OPERAND_IMM;
+            }
+            opa.value = static_cast<rword>(op.getImm());
+            instAnalysis->numOperands++;
+        }
+    }
+
+    // analyse implicit registers (R/W)
+    analyseImplicitRegisters(instAnalysis, desc.getImplicitDefs(), skipRegs, REGISTER_WRITE, MRI);
+    analyseImplicitRegisters(instAnalysis, desc.getImplicitUses(), skipRegs, REGISTER_READ, MRI);
+}
+
+} // namespace anonymous
+
+void InstAnalysisDestructor::operator()(InstAnalysis* ptr) const {
+    if (ptr == nullptr) {
+        return;
+    }
+    if (ptr->operands != nullptr) {
+        delete[] ptr->operands;
+    }
+    if (ptr->disassembly != nullptr) {
+        delete[] ptr->disassembly;
+    }
+    delete ptr;
+}
+
+
+InstAnalysisPtr analyzeInstMetadata_uncached(const InstMetadata& instMetadata, AnalysisType type,
+                                             const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI,
+                                             const Assembly& assembly) {
+
+    const llvm::MCInst &inst = instMetadata.inst;
+    const llvm::MCInstrDesc &desc = MCII.get(inst.getOpcode());
+
+
+    InstAnalysis* instAnalysis = new InstAnalysis;
+    // set all values to NULL/0/false
+    memset(instAnalysis, 0, sizeof(InstAnalysis));
+
+    instAnalysis->analysisType      = type;
+
+    if (type & ANALYSIS_DISASSEMBLY) {
+        int len = 0;
+        std::string buffer;
+        llvm::raw_string_ostream bufferOs(buffer);
+        assembly.printDisasm(inst, instMetadata.address, bufferOs);
+        bufferOs.flush();
+        len = buffer.size() + 1;
+        instAnalysis->disassembly = new char[len];
+        strncpy(instAnalysis->disassembly, buffer.c_str(), len);
+        buffer.clear();
+    }
+
+    if (type & ANALYSIS_INSTRUCTION) {
+        instAnalysis->address           = instMetadata.address;
+        instAnalysis->instSize          = instMetadata.instSize;
+        instAnalysis->affectControlFlow = instMetadata.modifyPC;
+        instAnalysis->isBranch          = desc.isBranch();
+        instAnalysis->isCall            = desc.isCall();
+        instAnalysis->isReturn          = desc.isReturn();
+        instAnalysis->isCompare         = desc.isCompare();
+        instAnalysis->isPredicable      = desc.isPredicable();
+        instAnalysis->mayLoad           = desc.mayLoad();
+        instAnalysis->mayStore          = desc.mayStore();
+        instAnalysis->mnemonic          = MCII.getName(inst.getOpcode()).data();
+    }
+
+    if (type & ANALYSIS_OPERANDS) {
+        // analyse operands (immediates / registers)
+        analyseOperands(instAnalysis, inst, desc, MRI);
+    }
+
+    if (type & ANALYSIS_SYMBOL) {
+        // find nearest symbol (if any)
+#ifndef QBDI_PLATFORM_WINDOWS
+        Dl_info info;
+        const char* ptr;
+
+        int ret = dladdr((void*) instAnalysis->address, &info);
+        if (ret != 0) {
+            if (info.dli_sname) {
+                instAnalysis->symbol = info.dli_sname;
+                instAnalysis->symbolOffset = instAnalysis->address - (rword) info.dli_saddr;
+            }
+            if (info.dli_fname) {
+                // dirty basename, but thead safe
+                if((ptr = strrchr(info.dli_fname, '/')) != nullptr) {
+                    instAnalysis->module = ptr + 1;
+                }
+            }
+        }
+#endif
+    }
+
+    return InstAnalysisPtr(instAnalysis);
+}
+
+} // namespace QBDI

--- a/src/Utility/InstAnalysis_prive.h
+++ b/src/Utility/InstAnalysis_prive.h
@@ -39,9 +39,8 @@ struct InstAnalysisDestructor {
 
 using InstAnalysisPtr = std::unique_ptr<InstAnalysis, InstAnalysisDestructor>;
 
-InstAnalysisPtr analyzeInstMetadata_uncached(const InstMetadata& instMetadata, AnalysisType type,
-                                             const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI,
-                                             const Assembly& assembly);
+const InstAnalysis* analyzeInstMetadata(const InstMetadata& instMetadata, AnalysisType type,
+                                        const Assembly& assembly);
 
 }
 

--- a/src/Utility/InstAnalysis_prive.h
+++ b/src/Utility/InstAnalysis_prive.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of QBDI.
+ *
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INSTANALYSISPRIVE_H
+#define INSTANALYSISPRIVE_H
+
+#include <memory>
+
+#include "InstAnalysis.h"
+
+namespace llvm {
+  class MCInstrDesc;
+  class MCInstrInfo;
+  class MCRegisterInfo;
+}
+
+namespace QBDI {
+
+class Assembly;
+class InstMetadata;
+
+struct InstAnalysisDestructor {
+  void operator()(InstAnalysis* ptr) const;
+};
+
+using InstAnalysisPtr = std::unique_ptr<InstAnalysis, InstAnalysisDestructor>;
+
+InstAnalysisPtr analyzeInstMetadata_uncached(const InstMetadata& instMetadata, AnalysisType type,
+                                             const llvm::MCInstrInfo& MCII, const llvm::MCRegisterInfo& MRI,
+                                             const Assembly& assembly);
+
+}
+
+#endif
+

--- a/test/ExecBlock/ExecBlockManagerTest.cpp
+++ b/test/ExecBlock/ExecBlockManagerTest.cpp
@@ -36,7 +36,7 @@ QBDI::Patch::Vec getEmptyBB(QBDI::rword address) {
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, BasicBlockLookup") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
 
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424242));
     REQUIRE(nullptr == execBlockManager.getProgrammedExecBlock(0x13371337));
@@ -44,7 +44,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, BasicBlockLookup")
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ClearCache") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
 
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424242));
     REQUIRE(nullptr != execBlockManager.getProgrammedExecBlock(0x42424242));
@@ -53,7 +53,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ClearCache") {
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockReuse") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
 
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424242));
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424243));
@@ -62,7 +62,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockReuse") {
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockRegions") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
 
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424242));
     execBlockManager.writeBasicBlock(getEmptyBB(0x24242424));
@@ -71,7 +71,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockRegions")
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockAlloc") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
     QBDI::rword address = 0;
 
     for(address = 0; address < 0x1000; address++) {
@@ -83,7 +83,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, ExecBlockAlloc") {
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, CacheRewrite") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
     unsigned int i = 0;
 
     execBlockManager.writeBasicBlock(getEmptyBB(0x42424242));
@@ -97,7 +97,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, CacheRewrite") {
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, MultipleBasicBlockExecution") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
     QBDI::ExecBlock *block = nullptr;
     // Jit two different terminators
     QBDI::Patch::Vec terminator1 = getEmptyBB(0x42424242);
@@ -119,7 +119,7 @@ TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, MultipleBasicBlock
 }
 
 TEST_CASE_METHOD(ExecBlockManagerTest, "ExecBlockManagerTest, Stresstest") {
-    QBDI::ExecBlockManager execBlockManager(*MCII, *MRI, *assembly);
+    QBDI::ExecBlockManager execBlockManager(*assembly);
     QBDI::rword address = 0;
 
     for(address = 0; address < 1000; address++) {

--- a/tools/frida-qbdi.js
+++ b/tools/frida-qbdi.js
@@ -299,6 +299,7 @@ var QBDI_C = Object.freeze({
     deleteInstrumentation: _qbdibinder.bind('qbdi_deleteInstrumentation', 'uchar', ['pointer', 'uint32']),
     deleteAllInstrumentations: _qbdibinder.bind('qbdi_deleteAllInstrumentations', 'void', ['pointer']),
     getInstAnalysis: _qbdibinder.bind('qbdi_getInstAnalysis', 'pointer', ['pointer', 'uint32']),
+    getCachedInstAnalysis: _qbdibinder.bind('qbdi_getCachedInstAnalysis', 'pointer', ['pointer', rword, 'uint32']),
     recordMemoryAccess: _qbdibinder.bind('qbdi_recordMemoryAccess', 'uchar', ['pointer', 'uint32']),
     getInstMemoryAccess: _qbdibinder.bind('qbdi_getInstMemoryAccess', 'pointer', ['pointer', 'pointer']),
     getBBMemoryAccess: _qbdibinder.bind('qbdi_getBBMemoryAccess', 'pointer', ['pointer', 'pointer']),
@@ -1107,7 +1108,7 @@ class QBDI {
     }
 
     /**
-     * Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.
+     * Obtain the analysis of the current instruction. Analysis results are cached in the VM.
      * The validity of the returned pointer is only guaranteed until the end of the callback, else a deepcopy of the structure is required.
      *
      * @param [type] Properties to retrieve during analysis (default to ANALYSIS_INSTRUCTION | ANALYSIS_DISASSEMBLY).
@@ -1117,6 +1118,24 @@ class QBDI {
     getInstAnalysis(type) {
         type = type || (AnalysisType.ANALYSIS_INSTRUCTION | AnalysisType.ANALYSIS_DISASSEMBLY);
         var analysis = QBDI_C.getInstAnalysis(this.#vm, type);
+        if (analysis.isNull()) {
+            return NULL;
+        }
+        return this._parseInstAnalysis(analysis);
+    }
+
+    /**
+     * Obtain the analysis of a cached instruction. Analysis results are cached in the VM.
+     * The validity of the returned pointer is only guaranteed until the end of the callback, else a deepcopy of the structure is required.
+     *
+     * @param  addr   The address of the instruction to analyse.
+     * @param [type]  Properties to retrieve during analysis (default to ANALYSIS_INSTRUCTION | ANALYSIS_DISASSEMBLY).
+     *
+     * @return A InstAnalysis object containing the analysis result. null if the instruction isn't in the cache.
+     */
+    getCachedInstAnalysis(addr, type) {
+        type = type || (AnalysisType.ANALYSIS_INSTRUCTION | AnalysisType.ANALYSIS_DISASSEMBLY);
+        var analysis = QBDI_C.getCachedInstAnalysis(this.#vm, addr, type);
         if (analysis.isNull()) {
             return NULL;
         }

--- a/tools/pyqbdi/binding/VM.cpp
+++ b/tools/pyqbdi/binding/VM.cpp
@@ -230,19 +230,34 @@ void init_binding_VM(py::module& m) {
                 },
                 "Remove all the registered instrumentations.")
         .def("getInstAnalysis",
-                [](VM& vm, AnalysisType type) {
+                [](const VM& vm, AnalysisType type) {
                     return vm.getInstAnalysis(type);
                 },
-                "Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.",
-                py::arg_v("type",AnalysisType::ANALYSIS_INSTRUCTION | AnalysisType::ANALYSIS_DISASSEMBLY,
+                "Obtain the analysis of the current instruction. Analysis results are cached in the VM.",
+                py::arg_v("type", AnalysisType::ANALYSIS_INSTRUCTION | AnalysisType::ANALYSIS_DISASSEMBLY,
                             "AnalysisType.ANALYSIS_INSTRUCTION|AnalysisType.ANALYSIS_DISASSEMBLY"),
                 py::return_value_policy::copy)
         .def("getInstAnalysis",
-                [](VM& vm, int type) {
+                [](const VM& vm, int type) {
                     return vm.getInstAnalysis(static_cast<AnalysisType>(type));
                 },
-                "Obtain the analysis of an instruction metadata. Analysis results are cached in the VM.",
+                "Obtain the analysis of the current instruction. Analysis results are cached in the VM.",
                 "type"_a, py::return_value_policy::copy)
+        .def("getCachedInstAnalysis",
+                [](const VM& vm, rword address, AnalysisType type) {
+                    return vm.getCachedInstAnalysis(address, type);
+                },
+                "Obtain the analysis of a cached instruction. Analysis results are cached in the VM.",
+                "address"_a,
+                py::arg_v("type", AnalysisType::ANALYSIS_INSTRUCTION | AnalysisType::ANALYSIS_DISASSEMBLY,
+                            "AnalysisType.ANALYSIS_INSTRUCTION|AnalysisType.ANALYSIS_DISASSEMBLY"),
+                py::return_value_policy::copy)
+        .def("getCachedInstAnalysis",
+                [](const VM& vm, rword address, int type) {
+                    return vm.getCachedInstAnalysis(address, static_cast<AnalysisType>(type));
+                },
+                "Obtain the analysis of a cached instruction. Analysis results are cached in the VM.",
+                "address"_a, "type"_a, py::return_value_policy::copy)
         .def("recordMemoryAccess", &VM::recordMemoryAccess,
                 "Add instrumentation rules to log memory access using inline instrumentation and instruction shadows.",
                 "type"_a)


### PR DESCRIPTION
This is a split of #131.

- Move analyse of Instruction outside of ExecBlockManager
- Move InstAnalysis cache in ExecBlock
- Complete InstAnalysis when a type is missing
- Add VM::getCachedInstAnalysis