### PR TITLE
Expose Instrumentation Rule Callback

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,6 +32,14 @@ Next Version
   * Change algorithm for ``OperandAnalysis``. The type ``OPERAND_INVALID`` may be present in the list of operands when a register is unset with the current instruction.
     Many operands may describe the used of the same register when a register is used multiple times for different purposes by the instruction.
 
+* Add Instrumentation Callback :c:type:`QBDI_InstrumentDataCBK` and :cpp:type:`QBDI::InstrumentDataCBK` (`#151 <https://github.com/QBDI/QBDI/pull/151>`_)
+
+  The Instrumentation Callback receives an InstAnalysis of each instruction during the instrumentation process. Based on this analysis, the callback
+  may insert custom InstCallback for each instruction.
+
+  The call order of the callback has changed for the PREINST callback. If an instruction has multiple callbacks in PREINST position, they will be called
+  in the reverse order of registration.
+
 Internal update:
 
 * Update LLVM to LLVM 10.0.1 (`#104 <https://github.com/QBDI/QBDI/pull/104>`_ and `#139 <https://github.com/QBDI/QBDI/pull/139>`_)

--- a/docs/source/frida_bindings.rst
+++ b/docs/source/frida_bindings.rst
@@ -73,6 +73,10 @@ Instrumentation
 
 .. js:autofunction:: QBDI#addMnemonicCB
 
+.. js:autofunction:: QBDI#addInstrRule
+
+.. js:autofunction:: QBDI#addInstrRuleRange
+
 .. js:autofunction:: QBDI#deleteInstrumentation
 
 .. js:autofunction:: QBDI#deleteAllInstrumentations
@@ -415,6 +419,8 @@ Helpers
 Some functions helpful to interact with Frida interface and write scripts.
 
 .. js:autofunction:: QBDI#getModuleNames
+
+.. js:autofunction:: QBDI#newInstrRuleCallback
 
 .. js:autofunction:: QBDI#newInstCallback
 

--- a/docs/source/pyQBDI_bindings.rst
+++ b/docs/source/pyQBDI_bindings.rst
@@ -25,6 +25,7 @@ VM
 --
 
 .. autoclass:: pyqbdi.VM
+    :special-members: __init__
     :members:
 
 
@@ -50,7 +51,6 @@ InstAnalysis
 
 .. autoclass:: pyqbdi.OperandAnalysis
     :members:
-
 
 .. autodata:: pyqbdi.RegisterAccessType
 .. autodata:: pyqbdi.OperandType
@@ -78,6 +78,13 @@ Range
 -----
 
 .. autoclass:: pyqbdi.Range
+    :members:
+
+Instrument Rule Data
+--------------------
+
+.. autoclass:: pyqbdi.InstrumentDataCBK
+    :special-members: __init__
     :members:
 
 Miscellaneous

--- a/include/QBDI/Callback.h
+++ b/include/QBDI/Callback.h
@@ -21,8 +21,10 @@
 #include "Platform.h"
 #include "State.h"
 #include "Bitmask.h"
-
+#include "InstAnalysis.h"
 #ifdef __cplusplus
+#include <vector>
+
 namespace QBDI {
 #endif
 
@@ -30,11 +32,11 @@ namespace QBDI {
  */
 typedef enum {
     _QBDI_EI(CONTINUE)    = 0, /*!< The execution of the basic block continues. */
-    _QBDI_EI(BREAK_TO_VM) = 1, /*!< The execution breaks and returns to the VM causing a complete reevaluation of 
-                                *   the execution state. A BREAK_TO_VM is needed to ensure that modifications of 
+    _QBDI_EI(BREAK_TO_VM) = 1, /*!< The execution breaks and returns to the VM causing a complete reevaluation of
+                                *   the execution state. A BREAK_TO_VM is needed to ensure that modifications of
                                 *   the Program Counter or the program code are taken into account.
                                 */
-    _QBDI_EI(STOP)        = 2, /*!< Stops the execution of the program. This causes the run function to return 
+    _QBDI_EI(STOP)        = 2, /*!< Stops the execution of the program. This causes the run function to return
                                 *   early.
                                 */
 } VMAction;
@@ -49,11 +51,11 @@ typedef VMInstance* VMInstanceRef;
 #endif
 
 /*! Instruction callback function type.
- * 
+ *
  * @param[in] vm            VM instance of the callback.
- * @param[in] gprState      A structure containing the state of the General Purpose Registers. Modifying 
+ * @param[in] gprState      A structure containing the state of the General Purpose Registers. Modifying
  *                          it affects the VM execution accordingly.
- * @param[in] fprState      A structure containing the state of the Floating Point Registers. Modifying 
+ * @param[in] fprState      A structure containing the state of the Floating Point Registers. Modifying
  *                          it affects the VM execution accordingly.
  * @param[in] data          User defined data which can be defined when registering the callback.
  *
@@ -96,12 +98,12 @@ typedef struct {
 } VMState;
 
 /*! VM callback function type.
- * 
+ *
  * @param[in] vm            VM instance of the callback.
  * @param[in] vmState       A structure containing the current state of the VM.
- * @param[in] gprState      A structure containing the state of the General Purpose Registers. Modifying 
+ * @param[in] gprState      A structure containing the state of the General Purpose Registers. Modifying
  *                          it affects the VM execution accordingly.
- * @param[in] fprState      A structure containing the state of the Floating Point Registers. Modifying 
+ * @param[in] fprState      A structure containing the state of the Floating Point Registers. Modifying
  *                          it affects the VM execution accordingly.
  * @param[in] data          User defined data which can be defined when registering the callback.
  *
@@ -133,7 +135,42 @@ typedef struct {
     MemoryAccessType type; /*!< Memory access type (READ / WRITE) */
 } MemoryAccess;
 
+
 #ifdef __cplusplus
+struct InstrumentDataCBK {
+    InstPosition position;  /*!< Relative position of the event callback (PREINST / POSTINST). */
+    InstCallback cbk;       /*!< Address of the function to call when the instruction is executed */
+    void* data;             /*!< User defined data which will be forward to cbk */
+
+    InstrumentDataCBK(InstPosition position, InstCallback cbk, void* data) : position(position), cbk(cbk), data(data) {}
+};
+
+using InstrumentDataVec = std::vector<InstrumentDataCBK>*;
+#else
+typedef void* InstrumentDataVec;
+#endif
+
+/*! Instrument callback function type.
+ *
+ * @param[in]     vm                VM instance of the callback.
+ * @param[in]     inst              AnalysisType of the current instrumented Instruction.
+ * @param[in|out] cbks              An object to add the callback to apply for this instruction.
+ * @param[in]     data              User defined data which can be defined when registering the callback.
+ */
+typedef void (*QBDI_InstrumentCallback)(VMInstanceRef vm, const InstAnalysis *inst, InstrumentDataVec cbks, void* data);
+
+#ifdef __cplusplus
+
+/*! Instrument callback function type.
+ *
+ * @param[in] vm                VM instance of the callback.
+ * @param[in] inst              AnalysisType of the current instrumented Instruction.
+ * @param[in] data              User defined data which can be defined when registering the callback.
+ *
+ * @return                      Return cbk to call when this instruction is run.
+ */
+typedef std::vector<InstrumentDataCBK> (*InstrumentCallback)(VMInstanceRef vm, const InstAnalysis *inst, void* data);
+
 } // QBDI::
 #endif
 

--- a/include/QBDI/Callback.h
+++ b/include/QBDI/Callback.h
@@ -152,10 +152,10 @@ typedef void* InstrumentDataVec;
 
 /*! Instrument callback function type.
  *
- * @param[in]     vm                VM instance of the callback.
- * @param[in]     inst              AnalysisType of the current instrumented Instruction.
- * @param[in|out] cbks              An object to add the callback to apply for this instruction.
- * @param[in]     data              User defined data which can be defined when registering the callback.
+ * @param[in] vm                VM instance of the callback.
+ * @param[in] inst              AnalysisType of the current instrumented Instruction.
+ * @param[in] cbks              An object to add the callback to apply for this instruction.
+ * @param[in] data              User defined data which can be defined when registering the callback.
  */
 typedef void (*QBDI_InstrumentCallback)(VMInstanceRef vm, const InstAnalysis *inst, InstrumentDataVec cbks, void* data);
 

--- a/include/QBDI/VM_C.h
+++ b/include/QBDI/VM_C.h
@@ -206,9 +206,44 @@ QBDI_EXPORT void qbdi_setGPRState(VMInstanceRef instance, GPRState* gprState);
  */
 QBDI_EXPORT void qbdi_setFPRState(VMInstanceRef instance, FPRState* fprState);
 
-/*! Register a callback event for every memory access matching the type bitfield made by the instructions.
+/*! Add a custom instrumentation rule to the VM.
+ *
+ * @param[in] instance   VM instance.
+ * @param[in] cbk       A function pointer to the callback
+ * @param[in] type      Analyse type needed for this instruction function pointer to the callback
+ * @param[in] data      User defined data passed to the callback.
+ *
+ * @return The id of the registered instrumentation (or VMError::INVALID_EVENTID
+ * in case of failure).
+ */
+QBDI_EXPORT uint32_t qbdi_addInstrRule(VMInstanceRef instance, QBDI_InstrumentCallback cbk, AnalysisType type, void* data);
+
+/*! Add a custom instrumentation rule to the VM for a range of address
  *
  * @param[in] instance  VM instance.
+ * @param[in] start     Begin of the range of address where apply the rule
+ * @param[in] end       End of the range of address where apply the rule
+ * @param[in] cbk       A function pointer to the callback
+ * @param[in] type      Analyse type needed for this instruction function pointer to the callback
+ * @param[in] data      User defined data passed to the callback.
+ *
+ * @return The id of the registered instrumentation (or VMError::INVALID_EVENTID
+ * in case of failure).
+ */
+QBDI_EXPORT uint32_t qbdi_addInstrRuleRange(VMInstanceRef instance, rword start, rword end, QBDI_InstrumentCallback cbk, AnalysisType type, void* data);
+
+/*! Add a callback for the current instruction
+ *
+ * @param[in] cbks      InstrumentDataVec given in argument
+ * @param[in] position  Relative position of the callback (QBDI_PREINST / QBDI_POSTINST).
+ * @param[in] cbk       A function pointer to the callback
+ * @param[in] data      User defined data passed to the callback.
+ */
+QBDI_EXPORT void qbdi_addInstrumentData(InstrumentDataVec cbks, InstPosition position, InstCallback cbk, void* data);
+
+/*! Register a callback event for every memory access matching the type bitfield made by the instructions.
+ *
+ * @param[in] instance   VM instance.
  * @param[in] type       A mode bitfield: either QBDI_MEMORY_READ, QBDI_MEMORY_WRITE or both (QBDI_MEMORY_READ_WRITE).
  * @param[in] cbk        A function pointer to the callback.
  * @param[in] data       User defined data passed to the callback.

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -224,8 +224,9 @@ void Engine::changeVMInstanceRef(VMInstanceRef vminstance) {
     blockManager->changeVMInstanceRef(vminstance);
     execBroker->changeVMInstanceRef(vminstance);
 
-    for (auto& r : instrRules)
-      r.second->changeVMInstanceRef(vminstance);
+    for (auto& r : instrRules) {
+        r.second->changeVMInstanceRef(vminstance);
+    }
 }
 
 void Engine::initGPRState() {

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -219,12 +219,11 @@ public:
     /*! Add a custom instrumentation rule to the engine. Requires internal headers
      *
      * @param[in] rule A custom instrumentation rule.
-     * @param[in] top_list Place the rule before all existing rules of its category
      *
      * @return The id of the registered instrumentation (or VMError::INVALID_EVENTID
      * in case of failure).
      */
-    uint32_t    addInstrRule(std::unique_ptr<InstrRule> rule, bool top_list=false);
+    uint32_t    addInstrRule(std::unique_ptr<InstrRule>&& rule);
 
     /*! Register a callback event for a specific VM event.
      *

--- a/src/Engine/VM_C.cpp
+++ b/src/Engine/VM_C.cpp
@@ -247,4 +247,19 @@ void qbdi_clearCache(VMInstanceRef instance, rword start, rword end) {
     static_cast<VM*>(instance)->clearCache(start, end);
 }
 
+uint32_t qbdi_addInstrRule(VMInstanceRef instance, QBDI_InstrumentCallback cbk, AnalysisType type, void* data) {
+    RequireAction("VM_C::addInstrRule", instance, return VMError::INVALID_EVENTID);
+    return static_cast<VM*>(instance)->addInstrRule(cbk, type, data);
+}
+
+uint32_t qbdi_addInstrRuleRange(VMInstanceRef instance, rword start, rword end, QBDI_InstrumentCallback cbk, AnalysisType type, void* data) {
+    RequireAction("VM_C::addInstrRuleRange", instance, return VMError::INVALID_EVENTID);
+    return static_cast<VM*>(instance)->addInstrRuleRange(start, end, cbk, type, data);
+}
+
+void qbdi_addInstrumentData(InstrumentDataVec cbks, InstPosition position, InstCallback cbk, void* data) {
+    RequireAction("VM_C::qbdi_addInstrumentData", cbks, return);
+    cbks->emplace_back(position, cbk, data);
+}
+
 }

--- a/src/ExecBlock/ExecBlockManager.h
+++ b/src/ExecBlock/ExecBlockManager.h
@@ -39,7 +39,6 @@ class InstMetadata;
 class Patch;
 class RelocatableInst;
 
-
 struct InstLoc {
     uint16_t blockIdx;
     uint16_t instID;

--- a/src/Patch/InstTransform.h
+++ b/src/Patch/InstTransform.h
@@ -40,7 +40,7 @@ public:
 
     virtual void transform(llvm::MCInst &inst, rword address, size_t instSize, TempManager *temp_manager) const = 0;
 
-    virtual ~InstTransform() {}
+    virtual ~InstTransform() = default;
 };
 
 class SetOperand : public InstTransform, public AutoAlloc<InstTransform, SetOperand> {

--- a/src/Patch/InstrRule.cpp
+++ b/src/Patch/InstrRule.cpp
@@ -21,15 +21,13 @@
 #include "Patch/Patch.h"
 #include "Patch/PatchGenerator.h"
 #include "Patch/RelocatableInst.h"
+#include "Utility/InstAnalysis_prive.h"
 #include "Utility/LogSys.h"
 
 namespace QBDI {
 
-bool InstrRule::canBeApplied(const Patch &patch, const llvm::MCInstrInfo* MCII) const {
-    return condition->test(patch.metadata.inst, patch.metadata.address, patch.metadata.instSize, MCII);
-}
-
-void InstrRule::instrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI) const {
+void InstrRule::instrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                           const PatchGenerator::SharedPtrVec patchGen, bool breakToHost, InstPosition position) const {
     /* The instrument function needs to handle several different cases. An instrumentation can
      * be either prepended or appended to the patch and, in each case, can trigger a break to
      * host.
@@ -120,6 +118,34 @@ void InstrRule::instrument(Patch &patch, const llvm::MCInstrInfo* MCII, const ll
         LogError("InstrRule::Instrument", "Invalid position 0x%x", position);
         abort();
     }
+}
+
+bool InstrRuleBasic::canBeApplied(const Patch &patch, const llvm::MCInstrInfo* MCII) const {
+    return condition->test(patch.metadata.inst, patch.metadata.address, patch.metadata.instSize, MCII);
+}
+
+bool InstrRuleUser::tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                                  const Assembly* assembly) const {
+    if (!range.contains(Range<rword>(patch.metadata.address, patch.metadata.address + patch.metadata.instSize))) {
+        return false;
+    }
+
+    LogDebug("InstrRuleUser::tryInstrument", "Call user InstrCB at %p with analysisType 0x%x", cbk, analysisType);
+
+    const InstAnalysis* ana = analyzeInstMetadata(patch.metadata, analysisType, *assembly);
+
+    std::vector<InstrumentDataCBK> vec = cbk(vm, ana, cbk_data);
+
+    LogDebug("InstrRuleUser::tryInstrument", "InstrCB return %u callback(s)", vec.size());
+
+    if (vec.size() == 0)
+        return false;
+
+    for (const InstrumentDataCBK& cbkToAdd : vec) {
+        instrument(patch, MCII, MRI, getCallbackGenerator(cbkToAdd.cbk, cbkToAdd.data), true, cbkToAdd.position);
+    }
+
+    return true;
 }
 
 }

--- a/src/Patch/InstrRule.cpp
+++ b/src/Patch/InstrRule.cpp
@@ -138,8 +138,9 @@ bool InstrRuleUser::tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, c
 
     LogDebug("InstrRuleUser::tryInstrument", "InstrCB return %u callback(s)", vec.size());
 
-    if (vec.size() == 0)
+    if (vec.size() == 0) {
         return false;
+    }
 
     for (const InstrumentDataCBK& cbkToAdd : vec) {
         instrument(patch, MCII, MRI, getCallbackGenerator(cbkToAdd.cbk, cbkToAdd.data), true, cbkToAdd.position);

--- a/src/Patch/InstrRule.h
+++ b/src/Patch/InstrRule.h
@@ -33,12 +33,66 @@ namespace llvm {
 
 namespace QBDI {
 
+class Assembly;
 class Patch;
 class PatchGenerator;
 
 /*! An instrumentation rule written in PatchDSL.
 */
-class InstrRule : public AutoAlloc<InstrRule, InstrRule> {
+class InstrRule {
+
+    protected:
+
+    // priority of the rule.
+    // The rule with the lesser priority will be applied first
+    int priority;
+
+    public:
+
+    InstrRule(int priority = 0) : priority(priority) {}
+
+    virtual ~InstrRule() = default;
+
+    virtual operator std::unique_ptr<InstrRule>() =0;
+
+    // virtual copy constructor used to duplicate the object
+    virtual std::unique_ptr<InstrRule> clone() const =0;
+
+    virtual RangeSet<rword> affectedRange() const =0;
+
+    int getPriority() const { return priority; };
+
+    void setPriority(int priority) { this->priority = priority; };
+
+    virtual void changeVMInstanceRef(VMInstanceRef vminstance) {};
+
+    /*! Determine wheter this rule have to be apply on this Path and instrument if needed.
+     *
+     * @param[in] patch     The current patch to instrument.
+     * @param[in] MCII      A LLVM::MCInstrInfo classes used for internal architecture specific
+     *                      queries.
+     * @param[in] MRI       A LLVM::MCRegisterInfo classes used for internal architecture specific
+     *                      queries.
+     * @param[in] assemby   Assembly object to generate InstAnalysis
+    */
+    virtual bool tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                               const Assembly* assembly) const =0;
+
+    /*! Instrument a patch by evaluating its generators on the current context. Also handles the
+     *  temporary register management for this patch.
+     *
+     * @param[in] patch  The current patch to instrument.
+     * @param[in] MCII   A LLVM::MCInstrInfo classes used for internal architecture specific
+     *                   queries.
+     * @param[in] MRI    A LLVM::MCRegisterInfo classes used for internal architecture specific
+     *                   queries.
+    */
+    void instrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                    const std::vector<std::shared_ptr<PatchGenerator>> patchGen, bool breakToHost, InstPosition position) const;
+};
+
+
+class InstrRuleBasic : public InstrRule {
 
     PatchCondition::SharedPtr                     condition;
     std::vector<std::shared_ptr<PatchGenerator>>  patchGen;
@@ -58,13 +112,23 @@ class InstrRule : public AutoAlloc<InstrRule, InstrRule> {
      * @param[in] breakToHost  A boolean determining whether this instrumentation should end with
      *                         a break to host (in the case of a callback for example).
     */
-    InstrRule(PatchCondition::SharedPtr condition, std::vector<std::shared_ptr<PatchGenerator>> patchGen,
-              InstPosition position, bool breakToHost) : condition(condition),
-              patchGen(patchGen), position(position), breakToHost(breakToHost) {}
+    InstrRuleBasic(PatchCondition::SharedPtr condition, std::vector<std::shared_ptr<PatchGenerator>> patchGen,
+                   InstPosition position, bool breakToHost, int priority = 0) : InstrRule(priority), condition(condition), patchGen(patchGen),
+        position(position), breakToHost(breakToHost) {}
+
+    ~InstrRuleBasic() override = default;
+
+    operator std::unique_ptr<InstrRule>() override {
+        return std::make_unique<InstrRuleBasic>(*this);
+    }
+
+    std::unique_ptr<InstrRule> clone() const override {
+      return std::make_unique<InstrRuleBasic>(*this);
+    };
 
     InstPosition getPosition() const { return position; }
 
-    RangeSet<rword> affectedRange() const {
+    RangeSet<rword> affectedRange() const override {
         return condition->affectedRange();
     }
 
@@ -78,16 +142,51 @@ class InstrRule : public AutoAlloc<InstrRule, InstrRule> {
     */
     bool canBeApplied(const Patch &patch, const llvm::MCInstrInfo* MCII) const;
 
-    /*! Instrument a patch by evaluating its generators on the current context. Also handles the
-     *  temporary register management for this patch.
-     *
-     * @param[in] patch  The current patch to instrument.
-     * @param[in] MCII   A LLVM::MCInstrInfo classes used for internal architecture specific
-     *                   queries.
-     * @param[in] MRI    A LLVM::MCRegisterInfo classes used for internal architecture specific
-     *                   queries.
-    */
-    void instrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI) const;
+    bool tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                       const Assembly* assembly) const override {
+        if (canBeApplied(patch, MCII)) {
+            instrument(patch, MCII, MRI, patchGen, breakToHost, position);
+            return true;
+        }
+        return false;
+    }
+};
+
+class InstrRuleUser : public InstrRule {
+
+    InstrumentCallback cbk;
+    AnalysisType analysisType;
+    void* cbk_data;
+    VMInstanceRef vm;
+    RangeSet<rword> range;
+
+    public:
+
+    InstrRuleUser(InstrumentCallback cbk, AnalysisType analysisType,
+                  void* cbk_data, VMInstanceRef vm, RangeSet<rword> range,
+                  int priority = 0) : InstrRule(priority),
+        cbk(cbk), analysisType(analysisType), cbk_data(cbk_data), vm(vm), range(range) {}
+
+    ~InstrRuleUser() override = default;
+
+    operator std::unique_ptr<InstrRule>() override {
+        return std::make_unique<InstrRuleUser>(*this);
+    }
+
+    std::unique_ptr<InstrRule> clone() const override {
+      return std::make_unique<InstrRuleUser>(*this);
+    };
+
+    void changeVMInstanceRef(VMInstanceRef vminstance) override {
+        vm = vminstance;
+    };
+
+    RangeSet<rword> affectedRange() const override {
+        return range;
+    }
+
+    bool tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                       const Assembly* assembly) const override;
 };
 
 }

--- a/src/Patch/InstrRule.h
+++ b/src/Patch/InstrRule.h
@@ -60,11 +60,11 @@ class InstrRule {
 
     virtual RangeSet<rword> affectedRange() const =0;
 
-    int getPriority() const { return priority; };
+    inline int getPriority() const { return priority; };
 
-    void setPriority(int priority) { this->priority = priority; };
+    inline void setPriority(int priority) { this->priority = priority; };
 
-    virtual void changeVMInstanceRef(VMInstanceRef vminstance) {};
+    inline virtual void changeVMInstanceRef(VMInstanceRef vminstance) {};
 
     /*! Determine wheter this rule have to be apply on this Path and instrument if needed.
      *
@@ -118,17 +118,17 @@ class InstrRuleBasic : public InstrRule {
 
     ~InstrRuleBasic() override = default;
 
-    operator std::unique_ptr<InstrRule>() override {
+    inline operator std::unique_ptr<InstrRule>() override {
         return std::make_unique<InstrRuleBasic>(*this);
     }
 
-    std::unique_ptr<InstrRule> clone() const override {
-      return std::make_unique<InstrRuleBasic>(*this);
+    inline std::unique_ptr<InstrRule> clone() const override {
+        return std::make_unique<InstrRuleBasic>(*this);
     };
 
-    InstPosition getPosition() const { return position; }
+    inline InstPosition getPosition() const { return position; }
 
-    RangeSet<rword> affectedRange() const override {
+    inline RangeSet<rword> affectedRange() const override {
         return condition->affectedRange();
     }
 
@@ -142,8 +142,8 @@ class InstrRuleBasic : public InstrRule {
     */
     bool canBeApplied(const Patch &patch, const llvm::MCInstrInfo* MCII) const;
 
-    bool tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
-                       const Assembly* assembly) const override {
+    inline bool tryInstrument(Patch &patch, const llvm::MCInstrInfo* MCII, const llvm::MCRegisterInfo* MRI,
+                              const Assembly* assembly) const override {
         if (canBeApplied(patch, MCII)) {
             instrument(patch, MCII, MRI, patchGen, breakToHost, position);
             return true;
@@ -169,19 +169,19 @@ class InstrRuleUser : public InstrRule {
 
     ~InstrRuleUser() override = default;
 
-    operator std::unique_ptr<InstrRule>() override {
+    inline operator std::unique_ptr<InstrRule>() override {
         return std::make_unique<InstrRuleUser>(*this);
     }
 
-    std::unique_ptr<InstrRule> clone() const override {
-      return std::make_unique<InstrRuleUser>(*this);
+    inline std::unique_ptr<InstrRule> clone() const override {
+        return std::make_unique<InstrRuleUser>(*this);
     };
 
-    void changeVMInstanceRef(VMInstanceRef vminstance) override {
+    inline void changeVMInstanceRef(VMInstanceRef vminstance) override {
         vm = vminstance;
     };
 
-    RangeSet<rword> affectedRange() const override {
+    inline RangeSet<rword> affectedRange() const override {
         return range;
     }
 

--- a/src/Patch/PatchCondition.h
+++ b/src/Patch/PatchCondition.h
@@ -52,7 +52,7 @@ public:
         return r;
     }
 
-    virtual ~PatchCondition() {};
+    virtual ~PatchCondition() = default;
 };
 
 class MnemonicIs : public PatchCondition, public AutoAlloc<PatchCondition, MnemonicIs> {

--- a/src/Patch/PatchGenerator.h
+++ b/src/Patch/PatchGenerator.h
@@ -48,7 +48,7 @@ public:
     virtual std::vector<std::shared_ptr<RelocatableInst>> generate(const llvm::MCInst *inst,
         rword address, rword instSize, TempManager *temp_manager, const Patch *toMerge) const = 0;
 
-    virtual ~PatchGenerator() {};
+    virtual ~PatchGenerator() = default;
 
     virtual bool modifyPC() const { return false; }
 

--- a/src/Patch/RelocatableInst.h
+++ b/src/Patch/RelocatableInst.h
@@ -42,7 +42,7 @@ public:
 
     virtual llvm::MCInst reloc(ExecBlock *exec_block) const =0;
 
-    virtual ~RelocatableInst() {};
+    virtual ~RelocatableInst() = default;
 };
 
 class NoReloc : public RelocatableInst, public AutoAlloc<RelocatableInst, NoReloc> {

--- a/src/Utility/InstAnalysis.cpp
+++ b/src/Utility/InstAnalysis.cpp
@@ -41,7 +41,6 @@
 #endif
 
 namespace QBDI {
-
 namespace {
 
 static bool isFlagRegister(unsigned int regNo) {

--- a/src/Utility/InstAnalysis_prive.h
+++ b/src/Utility/InstAnalysis_prive.h
@@ -49,4 +49,3 @@ bool isSupportedOperandType(unsigned opType);
 }
 
 #endif
-

--- a/test/API/VMTest.cpp
+++ b/test/API/VMTest.cpp
@@ -633,7 +633,8 @@ struct MoveCallbackStruct {
 
     bool reachEventCB;
     bool reachInstCB;
-    bool reachCB2 = false;
+    bool reachInstrumentCB;
+    bool reachCB2;
 };
 
 static QBDI::VMAction allowedNewBlock(QBDI::VMInstanceRef vm, const QBDI::VMState* state, QBDI::GPRState*, QBDI::FPRState*, void *data_) {
@@ -643,6 +644,15 @@ static QBDI::VMAction allowedNewBlock(QBDI::VMInstanceRef vm, const QBDI::VMStat
 
     data->reachEventCB = true;
     return QBDI::VMAction::CONTINUE;
+}
+
+static std::vector<QBDI::InstrumentDataCBK> instrumentCopyCB(QBDI::VMInstanceRef vm, const QBDI::InstAnalysis *inst, void* data_) {
+    MoveCallbackStruct* data = static_cast<MoveCallbackStruct*>(data_);
+    CHECK(data->expectedRef == vm);
+    CHECK(data->allowedNewBlock);
+
+    data->reachInstrumentCB = true;
+    return {};
 }
 
 static QBDI::VMAction verifyVMRef(QBDI::VMInstanceRef vm, QBDI::GPRState*, QBDI::FPRState*, void *data_) {
@@ -666,12 +676,13 @@ TEST_CASE("VMTest-MoveConstructor") {
     VMTest vm1;
     QBDI::VM* vm = vm1.vm.get();
 
-    MoveCallbackStruct data {vm, true, false, false};
+    MoveCallbackStruct data {vm, true, false, false, false, false};
 
     bool instrumented = vm->addInstrumentedModuleFromAddr((QBDI::rword)&dummyFunCall);
     REQUIRE(instrumented);
 
     vm->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data);
+    vm->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data);
     vm->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data);
 
     QBDI::rword retvalue;
@@ -680,9 +691,11 @@ TEST_CASE("VMTest-MoveConstructor") {
     REQUIRE(retvalue == 350);
     REQUIRE(data.reachEventCB);
     REQUIRE(data.reachInstCB);
+    REQUIRE(data.reachInstrumentCB);
 
     data.reachEventCB = false;
     data.reachInstCB = false;
+    data.reachInstrumentCB = false;
     data.allowedNewBlock = false;
 
     vm = vm1.vm.release();
@@ -697,9 +710,16 @@ TEST_CASE("VMTest-MoveConstructor") {
     data.expectedRef = &movedVM;
 
     movedVM.call(&retvalue, (QBDI::rword) dummyFun1, {780});
+
     REQUIRE(retvalue == 780);
     REQUIRE(data.reachEventCB);
     REQUIRE(data.reachInstCB);
+    REQUIRE_FALSE(data.reachInstrumentCB);
+
+
+    data.allowedNewBlock = true;
+    movedVM.precacheBasicBlock((QBDI::rword) dummyFun0);
+    REQUIRE(data.reachInstrumentCB);
 }
 
 TEST_CASE("VMTest-CopyConstructor") {
@@ -707,12 +727,13 @@ TEST_CASE("VMTest-CopyConstructor") {
     VMTest vm1;
     QBDI::VM* vm = vm1.vm.get();
 
-    MoveCallbackStruct data {vm, true, false, false};
+    MoveCallbackStruct data {vm, true, false, false, false, false};
 
     bool instrumented = vm->addInstrumentedModuleFromAddr((QBDI::rword)&dummyFunCall);
     REQUIRE(instrumented);
 
     vm->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data);
+    vm->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data);
     vm->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data);
 
     QBDI::rword retvalue;
@@ -721,9 +742,11 @@ TEST_CASE("VMTest-CopyConstructor") {
     REQUIRE(retvalue == 350);
     REQUIRE(data.reachEventCB);
     REQUIRE(data.reachInstCB);
+    REQUIRE(data.reachInstrumentCB);
 
     data.reachEventCB = false;
     data.reachInstCB = false;
+    data.reachInstrumentCB = false;
     data.allowedNewBlock = false;
 
     // copy vm
@@ -735,9 +758,11 @@ TEST_CASE("VMTest-CopyConstructor") {
     REQUIRE(retvalue == 620);
     REQUIRE(data.reachEventCB);
     REQUIRE(data.reachInstCB);
+    REQUIRE_FALSE(data.reachInstrumentCB);
 
     data.reachEventCB = false;
     data.reachInstCB = false;
+    data.reachInstrumentCB = false;
     data.allowedNewBlock = true;
     data.expectedRef = &movedVM;
 
@@ -745,6 +770,7 @@ TEST_CASE("VMTest-CopyConstructor") {
     REQUIRE(retvalue == 780);
     REQUIRE(data.reachEventCB);
     REQUIRE(data.reachInstCB);
+    REQUIRE(data.reachInstrumentCB);
 }
 
 TEST_CASE("VMTest-MoveAssignmentOperator") {
@@ -755,8 +781,8 @@ TEST_CASE("VMTest-MoveAssignmentOperator") {
     QBDI::VM* vm2 = vm2_.vm.get();
     REQUIRE( vm1 != vm2 );
 
-    MoveCallbackStruct data1 {vm1, true, false, false};
-    MoveCallbackStruct data2 {vm2, true, false, false};
+    MoveCallbackStruct data1 {vm1, true, false, false, false, false};
+    MoveCallbackStruct data2 {vm2, true, false, false, false, false};
 
     bool instrumented = vm1->addInstrumentedModuleFromAddr((QBDI::rword)&dummyFunCall);
     REQUIRE(instrumented);
@@ -764,9 +790,11 @@ TEST_CASE("VMTest-MoveAssignmentOperator") {
     REQUIRE(instrumented);
 
     vm1->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data1);
+    vm1->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data1);
     vm1->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data1);
 
     vm2->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data2);
+    vm2->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data2);
     vm2->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data2);
 
     QBDI::rword retvalue;
@@ -775,18 +803,22 @@ TEST_CASE("VMTest-MoveAssignmentOperator") {
     REQUIRE(retvalue == 350);
     REQUIRE(data1.reachEventCB);
     REQUIRE(data1.reachInstCB);
+    REQUIRE(data1.reachInstrumentCB);
 
     data1.reachEventCB = false;
     data1.reachInstCB = false;
+    data1.reachInstrumentCB = false;
     data1.allowedNewBlock = false;
 
     vm2->call(&retvalue, (QBDI::rword) dummyFun1, {670});
     REQUIRE(retvalue == 670);
     REQUIRE(data2.reachEventCB);
     REQUIRE(data2.reachInstCB);
+    REQUIRE(data2.reachInstrumentCB);
 
     data2.reachEventCB = false;
     data2.reachInstCB = false;
+    data2.reachInstrumentCB = false;
     data2.allowedNewBlock = false;
 
     data1.expectedRef = vm2;
@@ -800,11 +832,18 @@ TEST_CASE("VMTest-MoveAssignmentOperator") {
     vm1 = nullptr;
 
     vm2->call(&retvalue, (QBDI::rword) dummyFun1, {780});
+
     REQUIRE(retvalue == 780);
     REQUIRE(data1.reachEventCB);
     REQUIRE(data1.reachInstCB);
-    REQUIRE(( not data2.reachEventCB));
-    REQUIRE(( not data2.reachInstCB));
+    REQUIRE_FALSE(data1.reachInstrumentCB);
+    REQUIRE_FALSE(data2.reachEventCB);
+    REQUIRE_FALSE(data2.reachInstCB);
+    REQUIRE_FALSE(data2.reachInstrumentCB);
+
+    data1.allowedNewBlock = true;
+    vm2->precacheBasicBlock((QBDI::rword) dummyFun0);
+    REQUIRE(data1.reachInstrumentCB);
 }
 
 TEST_CASE("VMTest-CopyAssignmentOperator") {
@@ -815,8 +854,8 @@ TEST_CASE("VMTest-CopyAssignmentOperator") {
     QBDI::VM* vm2 = vm2_.vm.get();
     REQUIRE( vm1 != vm2 );
 
-    MoveCallbackStruct data1 {vm1, true, false, false};
-    MoveCallbackStruct data2 {vm2, true, false, false};
+    MoveCallbackStruct data1 {vm1, true, false, false, false, false};
+    MoveCallbackStruct data2 {vm2, true, false, false, false, false};
 
     bool instrumented = vm1->addInstrumentedModuleFromAddr((QBDI::rword)&dummyFunCall);
     REQUIRE(instrumented);
@@ -825,9 +864,11 @@ TEST_CASE("VMTest-CopyAssignmentOperator") {
 
     vm1->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data1);
     vm1->addCodeCB(QBDI::InstPosition::POSTINST, verifyCB2, &data1);
+    vm1->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data1);
     vm1->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data1);
 
     vm2->addCodeCB(QBDI::InstPosition::POSTINST, verifyVMRef, &data2);
+    vm2->addInstrRule(instrumentCopyCB, QBDI::ANALYSIS_INSTRUCTION, &data2);
     vm2->addVMEventCB(QBDI::SEQUENCE_ENTRY | QBDI::SEQUENCE_EXIT | QBDI::BASIC_BLOCK_NEW, allowedNewBlock, &data2);
 
     QBDI::rword retvalue;
@@ -836,10 +877,12 @@ TEST_CASE("VMTest-CopyAssignmentOperator") {
     REQUIRE(retvalue == 350);
     REQUIRE(data1.reachEventCB);
     REQUIRE(data1.reachInstCB);
+    REQUIRE(data1.reachInstrumentCB);
     REQUIRE(data1.reachCB2);
 
     data1.reachEventCB = false;
     data1.reachInstCB = false;
+    data1.reachInstrumentCB = false;
     data1.allowedNewBlock = false;
     data1.reachCB2 = false;
 
@@ -847,10 +890,12 @@ TEST_CASE("VMTest-CopyAssignmentOperator") {
     REQUIRE(retvalue == 670);
     REQUIRE(data2.reachEventCB);
     REQUIRE(data2.reachInstCB);
-    REQUIRE(( not data2.reachCB2));
+    REQUIRE(data2.reachInstrumentCB);
+    REQUIRE_FALSE(data2.reachCB2);
 
     data2.reachEventCB = false;
     data2.reachInstCB = false;
+    data2.reachInstrumentCB = false;
     data2.allowedNewBlock = false;
     data2.expectedRef = nullptr;
 
@@ -861,23 +906,29 @@ TEST_CASE("VMTest-CopyAssignmentOperator") {
     REQUIRE(retvalue == 780);
     REQUIRE(data1.reachEventCB);
     REQUIRE(data1.reachInstCB);
+    REQUIRE_FALSE(data1.reachInstrumentCB);
     REQUIRE(data1.reachCB2);
-    REQUIRE(( not data2.reachEventCB));
-    REQUIRE(( not data2.reachInstCB));
-    REQUIRE(( not data2.reachCB2));
+    REQUIRE_FALSE(data2.reachEventCB);
+    REQUIRE_FALSE(data2.reachInstCB);
+    REQUIRE_FALSE(data2.reachCB2);
+    REQUIRE_FALSE(data2.reachInstrumentCB);
 
     data1.reachEventCB = false;
     data1.reachInstCB = false;
+    data1.reachInstrumentCB = false;
     data1.allowedNewBlock = true;
     data1.expectedRef = vm2;
     data1.reachCB2 = false;
 
     vm2->call(&retvalue, (QBDI::rword) dummyFun1, {567});
+
     REQUIRE(retvalue == 567);
     REQUIRE(data1.reachEventCB);
     REQUIRE(data1.reachInstCB);
+    REQUIRE(data1.reachInstrumentCB);
     REQUIRE(data1.reachCB2);
-    REQUIRE(( not data2.reachEventCB));
-    REQUIRE(( not data2.reachInstCB));
-    REQUIRE(( not data2.reachCB2));
+    REQUIRE_FALSE(data2.reachEventCB);
+    REQUIRE_FALSE(data2.reachInstCB);
+    REQUIRE_FALSE(data2.reachCB2);
+    REQUIRE_FALSE(data2.reachInstrumentCB);
 }

--- a/tools/pyqbdi/binding/CMakeLists.txt
+++ b/tools/pyqbdi/binding/CMakeLists.txt
@@ -14,4 +14,7 @@ source_group("Source Files\\BINDING" FILES ${BINDING_PYTHON_SRC})
 
 target_sources(pyqbdi_module INTERFACE "${BINDING_PYTHON_SRC}")
 
+target_include_directories(pyqbdi_module INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
 

--- a/tools/pyqbdi/binding/Callback.cpp
+++ b/tools/pyqbdi/binding/Callback.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "pyqbdi.hpp"
+#include "callback_python.h"
 
 namespace QBDI {
 namespace pyQBDI {
@@ -92,6 +93,12 @@ void init_binding_Callback(py::module_& m) {
         .def_readwrite("value", &MemoryAccess::value, "Value read from / written to memory")
         .def_readwrite("size", &MemoryAccess::size, "Size of memory access (in bytes)")
         .def_readwrite("type", &MemoryAccess::type, "Memory access type (READ / WRITE)");
+
+    py::class_<InstrumentDataCBKPython>(m, "InstrumentDataCBK")
+        .def(py::init<PyInstCallback&, py::object&, InstPosition>(), "cbk"_a, "data"_a, "position"_a)
+        .def_readwrite("cbk", &InstrumentDataCBKPython::cbk, "Address of the function to call when the instruction is executed")
+        .def_readwrite("data", &InstrumentDataCBKPython::data, "User defined data which will be forward to cbk.")
+        .def_readwrite("position", &InstrumentDataCBKPython::position, "Relative position of the event callback (PREINST / POSTINST).");
 }
 
 }}

--- a/tools/pyqbdi/binding/callback_python.h
+++ b/tools/pyqbdi/binding/callback_python.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of QBDI.
+ *
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CALLBACK_PYTHON_H_
+#define CALLBACK_PYTHON_H_
+
+#include "pyqbdi.hpp"
+
+namespace QBDI {
+namespace pyQBDI {
+
+// Python Callback
+using PyInstCallback = std::function<VMAction(VMInstanceRef, GPRState*, FPRState*, py::object&)>;
+using PyVMCallback = std::function<VMAction(VMInstanceRef, const VMState*, GPRState*, FPRState*, py::object&)>;
+
+struct InstrumentDataCBKPython {
+    PyInstCallback cbk;
+    py::object data;
+    InstPosition position;
+
+    InstrumentDataCBKPython(PyInstCallback& cbk, py::object& data, InstPosition position) :
+        cbk(cbk), data(data), position(position) {}
+};
+
+using PyInstrRuleCallback = std::function<std::vector<InstrumentDataCBKPython>(VMInstanceRef, const InstAnalysis*, py::object&)>;
+
+}
+}
+
+#endif /* CALLBACK_PYTHON_H_ */


### PR DESCRIPTION
This is a split of #131.

- Add Callback during instrumentation process.
- Add missing documentation for frida binding
- Add missing field OperandAnalysis.flag to frida binding

Note:
I change the management of userdata in fridaQBDI. The pointer sent to QBDI is now a counter and no memory is allocated.