### PR TITLE
FS GS support for x86_64

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx==3.3.1
+docutils==0.17.1
 breathe==4.25.1
 sphinx-js==3.1
 sphinx_rtd_theme

--- a/docs/source/api_js.rst
+++ b/docs/source/api_js.rst
@@ -560,6 +560,7 @@ Other globals
     .. js:autoattribute:: OPT_DISABLE_FPR
     .. js:autoattribute:: OPT_DISABLE_OPTIONAL_FPR
     .. js:autoattribute:: OPT_ATT_SYNTAX
+    .. js:autoattribute:: OPT_ENABLE_FS_GS
 
 .. js:autoclass:: VMError
 

--- a/include/QBDI/arch/X86_64/Options.h
+++ b/include/QBDI/arch/X86_64/Options.h
@@ -40,9 +40,14 @@ typedef enum {
                                                 * execblock doesn't used FPR
                                                 */
   // architecture specific option between 24 and 31
-  _QBDI_EI(OPT_ATT_SYNTAX) = 1 << 24, /*!< Used the AT&T syntax for
-                                       * instruction disassembly
-                                       */
+  _QBDI_EI(OPT_ATT_SYNTAX) = 1 << 24,   /*!< Used the AT&T syntax for
+                                         * instruction disassembly
+                                         */
+  _QBDI_EI(OPT_ENABLE_FS_GS) = 1 << 25, /*!< Enable Backup/Restore of FS/GS
+                                         * segment. This option uses the
+                                         * instructions (RD|WR)(FS|GS)BASE that
+                                         * must be supported by the operating
+                                         * system */
 } Options;
 
 _QBDI_ENABLE_BITMASK_OPERATORS(Options)

--- a/include/QBDI/arch/X86_64/State.h
+++ b/include/QBDI/arch/X86_64/State.h
@@ -163,12 +163,15 @@ typedef struct QBDI_ALIGNED(8) {
   rword rsp;
   rword rip;
   rword eflags;
+  // Only backup and restore with OPT_ENABLE_FS_GS
+  rword fs;
+  rword gs;
 } GPRState;
 // SPHINX_X86_64_GPRSTATE_END
 
 static const char *const GPR_NAMES[] = {
-    "RAX", "RBX", "RCX", "RDX", "RSI", "RDI", "R8",  "R9",  "R10",
-    "R11", "R12", "R13", "R14", "R15", "RBP", "RSP", "RIP", "EFLAGS"};
+    "RAX", "RBX", "RCX", "RDX", "RSI", "RDI", "R8",  "R9",     "R10", "R11",
+    "R12", "R13", "R14", "R15", "RBP", "RSP", "RIP", "EFLAGS", "FS",  "GS"};
 
 static const unsigned int NUM_GPR = 17;
 static const unsigned int AVAILABLE_GPR = 14;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -155,6 +155,9 @@ void Engine::setOptions(Options options) {
 
     Options needRecreate =
         Options::OPT_DISABLE_FPR | Options::OPT_DISABLE_OPTIONAL_FPR;
+#if defined(QBDI_ARCH_X86_64)
+    needRecreate |= Options::OPT_ENABLE_FS_GS;
+#endif // QBDI_ARCH_X86_64
 
     // need to recreate all ExecBlock
     if (((this->options ^ options) & needRecreate) != 0) {

--- a/src/Engine/Engine.h
+++ b/src/Engine/Engine.h
@@ -87,6 +87,7 @@ public:
    *
    * @param[in] cpu        The name of the CPU
    * @param[in] mattrs     A list of additional attributes
+   * @param[in] opts       The options to enable
    * @param[in] vminstance Pointer to public engine interface
    */
   Engine(const std::string &cpu = "",

--- a/src/ExecBlock/ExecBlock.h
+++ b/src/ExecBlock/ExecBlock.h
@@ -189,7 +189,6 @@ public:
    *
    * @param seqStart [in] Iterator to the start of a list of patches.
    * @param seqEnd   [in] Iterator to the end of a list of patches.
-   * @param seqType  [in] Type of the sequence.
    *
    * @return A structure detailling the write operation result.
    */
@@ -302,13 +301,13 @@ public:
    */
   const llvm::MCInst &getOriginalMCInst(uint16_t instID) const;
 
-  /*! Obtain the analysis of an instruction metadata. Analysis results are
+  /*! Obtain the analysis of an instruction. Analysis results are
    * cached in the InstAnalysis. The validity of the returned pointer is only
    * guaranteed until the end of the callback, else a deepcopy of the structure
    * is required.
    *
-   * @param[in] instMetadata Metadata to analyze.
-   * @param[in] type         Properties to retrieve during analysis.
+   * @param[in] instID  The ID of the instruction to analyse.
+   * @param[in] type    Properties to retrieve during analysis.
    *
    * @return A InstAnalysis structure containing the analysis result.
    */

--- a/src/ExecBlock/X86_64/Context_X86_64.h
+++ b/src/ExecBlock/X86_64/Context_X86_64.h
@@ -26,6 +26,8 @@ namespace QBDI {
  */
 struct QBDI_ALIGNED(8) HostState {
   rword sp;
+  rword fs;
+  rword gs;
   rword selector;
   rword callback;
   rword data;

--- a/src/Patch/InstrRule.h
+++ b/src/Patch/InstrRule.h
@@ -75,8 +75,12 @@ public:
   /*! Instrument a patch by evaluating its generators on the current context.
    * Also handles the temporary register management for this patch.
    *
-   * @param[in] patch     The current patch to instrument.
-   * @param[in] llvmcpu   LLVMCPU object
+   * @param[in] patch       The current patch to instrument.
+   * @param[in] llvmcpu     LLVMCPU object
+   * @param[in] patchGen    The list of patchGenerator to apply
+   * @param[in] breakToHost Add a break to VM need to be add after the patch
+   * @param[in] position    Add the patch before or after the instruction
+   * @param[in] priority    The priority of this patch
    */
   void instrument(Patch &patch, const LLVMCPU &llvmcpu,
                   const PatchGeneratorUniquePtrVec &patchGen, bool breakToHost,

--- a/src/Patch/X86_64/ExecBlockFlags_X86_64.h
+++ b/src/Patch/X86_64/ExecBlockFlags_X86_64.h
@@ -22,7 +22,11 @@
 
 namespace QBDI {
 
-typedef enum : uint8_t { needAVX = 1 << 0, needFPU = 1 << 1 } ExecBlockFlags;
+typedef enum : uint8_t {
+  needAVX = 1 << 0,
+  needFPU = 1 << 1,
+  needFSGS = 1 << 2,
+} ExecBlockFlags;
 
 }
 

--- a/src/Patch/X86_64/Layer2_X86_64.cpp
+++ b/src/Patch/X86_64/Layer2_X86_64.cpp
@@ -436,6 +436,42 @@ llvm::MCInst ret() {
   return inst;
 }
 
+llvm::MCInst rdfsbase64(unsigned int reg) {
+  llvm::MCInst inst;
+
+  inst.setOpcode(llvm::X86::RDFSBASE64);
+  inst.addOperand(llvm::MCOperand::createReg(reg));
+
+  return inst;
+}
+
+llvm::MCInst rdgsbase64(unsigned int reg) {
+  llvm::MCInst inst;
+
+  inst.setOpcode(llvm::X86::RDGSBASE64);
+  inst.addOperand(llvm::MCOperand::createReg(reg));
+
+  return inst;
+}
+
+llvm::MCInst wrfsbase64(unsigned int reg) {
+  llvm::MCInst inst;
+
+  inst.setOpcode(llvm::X86::WRFSBASE64);
+  inst.addOperand(llvm::MCOperand::createReg(reg));
+
+  return inst;
+}
+
+llvm::MCInst wrgsbase64(unsigned int reg) {
+  llvm::MCInst inst;
+
+  inst.setOpcode(llvm::X86::WRGSBASE64);
+  inst.addOperand(llvm::MCOperand::createReg(reg));
+
+  return inst;
+}
+
 llvm::MCInst movrr(unsigned int dst, unsigned int src) {
   if constexpr (is_x86_64)
     return mov64rr(dst, src);
@@ -602,6 +638,22 @@ RelocatableInst::UniquePtr Je(int32_t offset) {
 
 RelocatableInst::UniquePtr Jne(int32_t offset) {
   return NoReloc::unique(jne(offset));
+}
+
+RelocatableInst::UniquePtr Rdfsbase(Reg reg) {
+  return NoReloc::unique(rdfsbase64(reg));
+}
+
+RelocatableInst::UniquePtr Rdgsbase(Reg reg) {
+  return NoReloc::unique(rdgsbase64(reg));
+}
+
+RelocatableInst::UniquePtr Wrfsbase(Reg reg) {
+  return NoReloc::unique(wrfsbase64(reg));
+}
+
+RelocatableInst::UniquePtr Wrgsbase(Reg reg) {
+  return NoReloc::unique(wrgsbase64(reg));
 }
 
 } // namespace QBDI

--- a/src/Patch/X86_64/Layer2_X86_64.h
+++ b/src/Patch/X86_64/Layer2_X86_64.h
@@ -116,6 +116,14 @@ llvm::MCInst popf64();
 
 llvm::MCInst ret();
 
+llvm::MCInst rdfsbase(unsigned int reg);
+
+llvm::MCInst rdgsbase(unsigned int reg);
+
+llvm::MCInst wrfsbase(unsigned int reg);
+
+llvm::MCInst wrgsbase(unsigned int reg);
+
 // low level layer 2 architecture abtraction
 
 llvm::MCInst movrr(unsigned int dst, unsigned int src);
@@ -191,6 +199,14 @@ std::unique_ptr<RelocatableInst> Test(Reg reg, unsigned int value);
 std::unique_ptr<RelocatableInst> Je(int32_t offset);
 
 std::unique_ptr<RelocatableInst> Jne(int32_t offset);
+
+std::unique_ptr<RelocatableInst> Rdfsbase(Reg reg);
+
+std::unique_ptr<RelocatableInst> Rdgsbase(Reg reg);
+
+std::unique_ptr<RelocatableInst> Wrfsbase(Reg reg);
+
+std::unique_ptr<RelocatableInst> Wrgsbase(Reg reg);
 
 } // namespace QBDI
 

--- a/src/Patch/X86_64/PatchRules_X86_64.cpp
+++ b/src/Patch/X86_64/PatchRules_X86_64.cpp
@@ -122,6 +122,26 @@ RelocatableInst::UniquePtrVec getExecBlockPrologue(Options opts) {
        // target je needAVX
     }
   }
+#if defined(QBDI_ARCH_X86_64)
+  // if enable FS GS
+  if ((opts & Options::OPT_ENABLE_FS_GS) == Options::OPT_ENABLE_FS_GS) {
+    QBDI_REQUIRE_ACTION(isHostCPUFeaturePresent("fsgsbase"), abort());
+
+    append(prologue,
+           LoadReg(Reg(0), Offset(offsetof(Context, hostState.executeFlags))));
+    prologue.push_back(Test(Reg(0), ExecBlockFlags::needFSGS));
+    prologue.push_back(Je(5 * 4 + 7 * 4 + 4));
+
+    append(prologue, LoadReg(Reg(3), Offset(offsetof(Context, gprState.fs))));
+    append(prologue, LoadReg(Reg(4), Offset(offsetof(Context, gprState.gs))));
+    prologue.push_back(Rdfsbase(Reg(1)));
+    prologue.push_back(Rdgsbase(Reg(2)));
+    prologue.push_back(Wrfsbase(Reg(3)));
+    prologue.push_back(Wrgsbase(Reg(4)));
+    append(prologue, SaveReg(Reg(1), Offset(offsetof(Context, hostState.fs))));
+    append(prologue, SaveReg(Reg(2), Offset(offsetof(Context, hostState.gs))));
+  }
+#endif // QBDI_ARCH_X86_64
   // Restore EFLAGS
   append(prologue, LoadReg(Reg(0), Offset(offsetof(Context, gprState.eflags))));
   prologue.push_back(Pushr(Reg(0)));
@@ -148,6 +168,26 @@ RelocatableInst::UniquePtrVec getExecBlockEpilogue(Options opts) {
   epilogue.push_back(Pushf());
   epilogue.push_back(Popr(Reg(0)));
   append(epilogue, SaveReg(Reg(0), Offset(offsetof(Context, gprState.eflags))));
+#if defined(QBDI_ARCH_X86_64)
+  // if enable FS GS
+  if ((opts & Options::OPT_ENABLE_FS_GS) == Options::OPT_ENABLE_FS_GS) {
+    QBDI_REQUIRE_ACTION(isHostCPUFeaturePresent("fsgsbase"), abort());
+
+    append(epilogue,
+           LoadReg(Reg(0), Offset(offsetof(Context, hostState.executeFlags))));
+    epilogue.push_back(Test(Reg(0), ExecBlockFlags::needFSGS));
+    epilogue.push_back(Je(5 * 4 + 7 * 4 + 4));
+
+    append(epilogue, LoadReg(Reg(3), Offset(offsetof(Context, hostState.fs))));
+    append(epilogue, LoadReg(Reg(4), Offset(offsetof(Context, hostState.gs))));
+    epilogue.push_back(Rdfsbase(Reg(1)));
+    epilogue.push_back(Rdgsbase(Reg(2)));
+    epilogue.push_back(Wrfsbase(Reg(3)));
+    epilogue.push_back(Wrgsbase(Reg(4)));
+    append(epilogue, SaveReg(Reg(1), Offset(offsetof(Context, gprState.fs))));
+    append(epilogue, SaveReg(Reg(2), Offset(offsetof(Context, gprState.gs))));
+  }
+#endif // QBDI_ARCH_X86_64
   // Save FPR
   if ((opts & Options::OPT_DISABLE_FPR) == 0) {
     if ((opts & Options::OPT_DISABLE_OPTIONAL_FPR) == 0) {

--- a/tools/frida-qbdi.js
+++ b/tools/frida-qbdi.js
@@ -337,7 +337,7 @@ if (Process.arch === 'x64') {
     /**
      * An array holding register names.
      */
-    var GPR_NAMES = ["RAX","RBX","RCX","RDX","RSI","RDI","R8","R9","R10","R11","R12","R13","R14","R15","RBP","RSP","RIP","EFLAGS"];
+    var GPR_NAMES = ["RAX","RBX","RCX","RDX","RSI","RDI","R8","R9","R10","R11","R12","R13","R14","R15","RBP","RSP","RIP","EFLAGS","FS","GS"];
     /**
      * A constant string representing the register carrying the return value of a function.
      */
@@ -728,7 +728,13 @@ var Options = Object.freeze({
     /**
      * Used the AT&T syntax for instruction disassembly (for X86 and X86_64)
      */
-    OPT_ATT_SYNTAX : 1<<24
+    OPT_ATT_SYNTAX : 1<<24,
+    /**
+     * Enable Backup/Restore of FS/GS segment. 
+     * This option uses the instructions (RD|WR)(FS|GS)BASE that must be 
+     * supported by the operating system.
+     */
+    OPT_ENABLE_FS_GS : 1<<25
 });
 
 class InstrRuleDataCBK {
@@ -865,7 +871,7 @@ class GPRState extends State  {
      */
     synchronizeContext(FridaCtx, direction) {
         for (var i in GPR_NAMES) {
-            if (GPR_NAMES[i] === "EFLAGS") {
+            if (GPR_NAMES[i] === "EFLAGS" || GPR_NAMES[i] === "FS" || GPR_NAMES[i] === "GS") {
                 continue;
             }
             this.synchronizeRegister(FridaCtx, GPR_NAMES[i], direction);

--- a/tools/pyqbdi/binding/X86_64/Options_X86_64.cpp
+++ b/tools/pyqbdi/binding/X86_64/Options_X86_64.cpp
@@ -34,6 +34,10 @@ void init_binding_Options(py::module_ &m) {
              "doesn't used FPR")
       .value("OPT_ATT_SYNTAX", Options::OPT_ATT_SYNTAX,
              "Used the AT&T syntax for instruction disassembly")
+      .value("OPT_ENABLE_FS_GS", Options::OPT_ENABLE_FS_GS,
+             "Enable Backup/Restore of FS/GS segment. This option uses the "
+             "instructions (RD|WR)(FS|GS)BASE that must be supported by the "
+             "operating system.")
       .export_values()
       .def_invert()
       .def_repr_str();

--- a/tools/pyqbdi/binding/X86_64/State_X86_64.cpp
+++ b/tools/pyqbdi/binding/X86_64/State_X86_64.cpp
@@ -515,6 +515,8 @@ void init_binding_State(py::module_ &m) {
       .def_readwrite("rsp", &GPRState::rsp)
       .def_readwrite("rip", &GPRState::rip)
       .def_readwrite("eflags", &GPRState::eflags)
+      .def_readwrite("fs", &GPRState::fs)
+      .def_readwrite("gs", &GPRState::gs)
       // cross architecture access
       .def_readwrite("REG_RETURN", &GPRState::rax, "shadow of rax")
       .def_readwrite("AVAILABLE_GPR", &GPRState::rbp, "shadow of rbp")
@@ -550,6 +552,8 @@ void init_binding_State(py::module_ &m) {
                  << "rsp    : 0x" << std::setw(r) << obj.rsp << std::endl
                  << "rip    : 0x" << std::setw(r) << obj.rip << std::endl
                  << "eflags : 0x" << std::setw(r) << obj.eflags << std::endl
+                 << "fs     : 0x" << std::setw(r) << obj.fs << std::endl
+                 << "gs     : 0x" << std::setw(r) << obj.gs << std::endl
                  << "=== GPRState end ===" << std::endl;
              return oss.str();
            })


### PR DESCRIPTION
Use `(RD|WR)(FS|GS)BASE` instruction to save / restore FS|GS

Tested on linux x64 (>= 5.9)

Experimental support for x86_64 only