### PR TITLE
Fix addInstrumentedModuleFromAddr to work with mmap region

### DIFF
--- a/src/ExecBroker/ExecBroker.cpp
+++ b/src/ExecBroker/ExecBroker.cpp
@@ -68,22 +68,26 @@ bool ExecBroker::addInstrumentedModule(const std::string &name) {
 }
 
 bool ExecBroker::addInstrumentedModuleFromAddr(rword addr) {
-  bool instrumented = false;
-
   for (const MemoryMap &m : getCurrentProcessMaps()) {
     if (m.range.contains(addr)) {
-      instrumented = addInstrumentedModule(m.name);
-      break;
+      if (not m.name.empty()) {
+        return addInstrumentedModule(m.name);
+      } else if (m.permission & QBDI::PF_EXEC) {
+        addInstrumentedRange(m.range);
+        return true;
+      } else {
+        return false;
+      }
     }
   }
-  return instrumented;
+  return false;
 }
 
 bool ExecBroker::removeInstrumentedModule(const std::string &name) {
   bool removed = false;
 
   for (const MemoryMap &m : getCurrentProcessMaps()) {
-    if ((m.name == name) && (m.permission & QBDI::PF_EXEC)) {
+    if (m.name == name) {
       removeInstrumentedRange(m.range);
       removed = true;
     }
@@ -92,15 +96,16 @@ bool ExecBroker::removeInstrumentedModule(const std::string &name) {
 }
 
 bool ExecBroker::removeInstrumentedModuleFromAddr(rword addr) {
-  bool removed = false;
-
   for (const MemoryMap &m : getCurrentProcessMaps()) {
     if (m.range.contains(addr)) {
-      removed = removeInstrumentedModule(m.name);
-      break;
+      removeInstrumentedRange(m.range);
+      if (not m.name.empty()) {
+        removeInstrumentedModule(m.name);
+      }
+      return true;
     }
   }
-  return removed;
+  return false;
 }
 
 bool ExecBroker::instrumentAllExecutableMaps() {


### PR DESCRIPTION
If a range without name is found with the address of  `addInstrumentedModuleFromAddr` and the range is executable, the range is added in the instrumented range.