### PR TITLE
No exec stack

### DIFF
--- a/src/ExecBlock/X86_64/CMakeLists.txt
+++ b/src/ExecBlock/X86_64/CMakeLists.txt
@@ -6,9 +6,14 @@ if(QBDI_PLATFORM_OSX
    OR QBDI_PLATFORM_ANDROID)
 
   if(QBDI_ARCH_X86_64)
-    list(APPEND SOURCES "${CMAKE_CURRENT_LIST_DIR}/linux-osx-X86_64.s")
+    set(ASM_STUB_EXECBLOCK "${CMAKE_CURRENT_LIST_DIR}/linux-osx-X86_64.s")
   else() # QBDI_ARCH_X86
-    list(APPEND SOURCES "${CMAKE_CURRENT_LIST_DIR}/linux-osx-X86.s")
+    set(ASM_STUB_EXECBLOCK "${CMAKE_CURRENT_LIST_DIR}/linux-osx-X86.s")
+  endif()
+  list(APPEND SOURCES "${ASM_STUB_EXECBLOCK}")
+  if(NOT QBDI_PLATFORM_OSX)
+    set_property(SOURCE "${ASM_STUB_EXECBLOCK}" PROPERTY COMPILE_FLAGS
+                                                         --noexecstack)
   endif()
 
 elseif(QBDI_PLATFORM_WINDOWS)

--- a/src/ExecBlock/X86_64/linux-osx-X86.s
+++ b/src/ExecBlock/X86_64/linux-osx-X86.s
@@ -42,4 +42,3 @@ _skip_save_fpu:
 _skip_restore_fpu:
     cld;
     ret;
-    


### PR DESCRIPTION
Add --noexecstack when compile ExecBlock stub for linux and android