### PR TITLE
Link QBDIPreload before QBDI

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -4,5 +4,5 @@ add_signature(fibonacci_c)
 
 if(QBDI_TOOLS_QBDIPRELOAD)
   add_library(tracer_preload_c SHARED tracer_preload.c)
-  target_link_libraries(tracer_preload_c QBDI_static QBDIPreload)
+  target_link_libraries(tracer_preload_c QBDIPreload QBDI_static)
 endif()

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ add_signature(fibonacci_cpp)
 
 if(QBDI_TOOLS_QBDIPRELOAD)
   add_library(tracer_preload_cpp SHARED tracer_preload.cpp)
-  target_link_libraries(tracer_preload_cpp QBDI_static QBDIPreload)
+  target_link_libraries(tracer_preload_cpp QBDIPreload QBDI_static)
   set_target_properties(tracer_preload_cpp PROPERTIES CXX_STANDARD 11
                                                       CXX_STANDARD_REQUIRED ON)
 endif()

--- a/templates/qbdi_preload_template/CMakeLists.txt.in
+++ b/templates/qbdi_preload_template/CMakeLists.txt.in
@@ -5,4 +5,4 @@ find_package(QBDI@QBDI_ARCH@ REQUIRED)
 find_package(QBDIPreload@QBDI_ARCH@ REQUIRED)
 
 add_library(qbdi_tracer SHARED qbdi_preload_template.c)
-target_link_libraries(qbdi_tracer QBDI::@QBDI_ARCH@::QBDI_static QBDIPreload::@QBDI_ARCH@::QBDIPreload)
+target_link_libraries(qbdi_tracer QBDIPreload::@QBDI_ARCH@::QBDIPreload QBDI::@QBDI_ARCH@::QBDI_static)


### PR DESCRIPTION
fix #208 

QBDIPreload target needs symbol from QBDI_static target. It must be placed before on the linker command line (see this [blogpost](https://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking)).