### PR TITLE
Add llvm opcode to InstAnalysis

### DIFF
--- a/include/QBDI/InstAnalysis.h
+++ b/include/QBDI/InstAnalysis.h
@@ -157,6 +157,8 @@ typedef struct {
   ConditionType condition; /*!< Condition associated with the instruction */
   bool mayLoad_LLVM;       // mayLoad of 0.7.1
   bool mayStore_LLVM;      // mayStore of 0.7.1
+  uint32_t opcode_LLVM;    // instruction opcode of LLVM (must used the exact
+                           // same version of llvm)
   // ANALYSIS_DISASSEMBLY
   char *disassembly; /*!< Instruction disassembly
                       * (warning: NULL if !ANALYSIS_DISASSEMBLY) */

--- a/src/Utility/InstAnalysis.cpp
+++ b/src/Utility/InstAnalysis.cpp
@@ -529,6 +529,7 @@ const InstAnalysis *analyzeInstMetadata(const InstMetadata &instMetadata,
         instAnalysis->loadSize != 0 || unsupportedRead(inst);
     instAnalysis->mayStore =
         instAnalysis->storeSize != 0 || unsupportedWrite(inst);
+    instAnalysis->opcode_LLVM = inst.getOpcode();
     instAnalysis->mayLoad_LLVM = desc.mayLoad();
     instAnalysis->mayStore_LLVM = desc.mayStore();
     instAnalysis->mnemonic = llvmcpu.getInstOpcodeName(inst);


### PR DESCRIPTION
For some project C++ project that may include the LLVM header, accessing to the LLVM instId can be more efficient that comparing mnemonic string. However, as QBDI doesn't expose LLVM header, this field will be left undocumented.