### PR TITLE
fix missing include to build on c++20

### DIFF
--- a/src/Patch/PatchGenerator.h
+++ b/src/Patch/PatchGenerator.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "QBDI/State.h"
+#include "Patch/InstTransform.h"
 #include "Patch/PatchUtils.h"
 #include "Patch/Types.h"
 


### PR DESCRIPTION
I get build failures on macOS when using C++20 due to a missing include. This fixes it.