### PR TITLE
Fix ArithExtendImm for address

### DIFF
--- a/src/Patch/AARCH64/Layer2_AARCH64.cpp
+++ b/src/Patch/AARCH64/Layer2_AARCH64.cpp
@@ -78,28 +78,28 @@ llvm::MCInst addr(RegLLVM dst, RegLLVM src1, RegLLVM src2, ShiftExtendType type,
   unsigned immValue;
   switch (type) {
     case UXTB:
-      immValue = (llvm::AArch64_AM::UXTB << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::UXTB, shift);
       break;
     case UXTH:
-      immValue = (llvm::AArch64_AM::UXTH << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::UXTH, shift);
       break;
     case UXTW:
-      immValue = (llvm::AArch64_AM::UXTW << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::UXTW, shift);
       break;
     case UXTX:
-      immValue = (llvm::AArch64_AM::UXTX << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::UXTX, shift);
       break;
     case SXTB:
-      immValue = (llvm::AArch64_AM::SXTB << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::SXTB, shift);
       break;
     case SXTH:
-      immValue = (llvm::AArch64_AM::SXTH << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::SXTH, shift);
       break;
     case SXTW:
-      immValue = (llvm::AArch64_AM::SXTW << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::SXTW, shift);
       break;
     case SXTX:
-      immValue = (llvm::AArch64_AM::SXTX << 3) | (shift & 0x7);
+      immValue = getArithExtendImm(llvm::AArch64_AM::SXTX, shift);
       break;
     default:
       QBDI_ABORT("Unexpected type %d", type);


### PR DESCRIPTION
The definition of ExtendEncoding has changed with the last update of llvm. We should use the new function provide by llvm to encode them in the instruction operand.

Fix #312 