### PR TITLE
Explicitly use non-executable stack.

### DIFF
--- a/src/ExecBlock/ARM/linux-android_ARM.s
+++ b/src/ExecBlock/ARM/linux-android_ARM.s
@@ -61,4 +61,4 @@ __qbdi_runCodeBlock:
     pop {r0-r12,pc};
 
 # mark stack as no-exec
-.section	.note.GNU-stack
+.section	.note.GNU-stack,"",%progbits

--- a/src/Utility/ARM/linux-android_ARM.s
+++ b/src/Utility/ARM/linux-android_ARM.s
@@ -46,4 +46,4 @@ __qbdi_asmStackSwitch:
     pop {fp, pc};
 
 # mark stack as no-exec
-.section	.note.GNU-stack
+.section	.note.GNU-stack,"",%progbits


### PR DESCRIPTION
The following error occurs when building with ndk r22 + `-target armv7-none-linux-androideabi21`:
```
error: changed section type for .note.GNU-stack, expected: 0x1
.section        .note.GNU-stack
```
This patch resolves the issue.