### PR TITLE
Fix cross-compiling from windows to android.

### DIFF
--- a/cmake/llvm/QBDI_llvm.cmake
+++ b/cmake/llvm/QBDI_llvm.cmake
@@ -145,9 +145,9 @@ if(QBDI_PLATFORM_WINDOWS)
 endif()
 
 if(NOT ("${QBDI_LLVM_TRIPLE}" STREQUAL ""))
-  set(LLVM_DEFAULT_TARGET_TRIPLE
+  set(LLVM_HOST_TRIPLE
       "${QBDI_LLVM_TRIPLE}"
-      CACHE STRING "set LLVM_DEFAULT_TARGET_TRIPLE")
+      CACHE STRING "set LLVM_HOST_TRIPLE")
 endif()
 
 # build llvm with visibility hidden


### PR DESCRIPTION
I encountered the following error:
```
 C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2512/q/qbdi/v0.12.0/source/build_273f2cf8/_deps/qbdi_llvm/llvm/lib/TargetParser/Unix/Host.inc:57:14: error: use of undeclared identifier 'LLVM_HOST_TRIPLE'
   57 |   if (Triple(LLVM_HOST_TRIPLE).getOS() == Triple::AIX) {
      |              ^
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2512/q/qbdi/v0.12.0/source/build_273f2cf8/_deps/qbdi_llvm/llvm/lib/TargetParser/Host.cpp:2145:58: error: use of undeclared identifier 'LLVM_HOST_TRIPLE'
 2145 |   std::string TargetTripleString = updateTripleOSVersion(LLVM_HOST_TRIPLE);
      |                                                          ^
2 errors generated.
```

The LLVM [cross-compilation documentation](https://llvm.org/docs/HowToCrossCompileLLVM.html) says:
>  - **LLVM_HOST_TRIPLE**: Specifies the target triple of the system the built LLVM will run on, which also implicitly sets other defaults such as LLVM_DEFAULT_TARGET_TRIPLE. ...

I think `LLVM_DEFAULT_TARGET_TRIPLE` may have been deprecated and is no longer supported.