### PR TITLE
fix operator recursion

### DIFF
--- a/src/Patch/Types.h
+++ b/src/Patch/Types.h
@@ -62,11 +62,11 @@ public:
 };
 
 inline bool operator==(unsigned int id, const RegLLVM &reg) {
-  return reg == id;
+  return reg.getValue() == id;
 }
 
 inline bool operator!=(unsigned int id, const RegLLVM &reg) {
-  return reg != id;
+  return reg.getValue() != id;
 }
 
 /*! Structure representing a register variable in PatchDSL.


### PR DESCRIPTION
compiling with C++ standard 20 and above will cause the VM to deadlock at runtime.

this is because C++20 introduced "rewritten candidates" for comparison operators, we can see the warning during compiling.

```
\Patch/Types.h(65): warning C5232: in C++20 this comparison calls 'bool QBDI::operator ==(unsigned int,const QBDI::RegLLVM &)' recursively
[972/1000] Building CXX object CMakeFiles\QBDI.dir\src\Utility\X86_64\InstAnalysis_X86_64.cpp.obj
```

this PR fixes the operators. I have confirmed the fibonacci_cpp example now works when compiling with C++20 and C++23 standard, where as before it did not.

example:
`cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_C_COMPILER=cl.exe -DQBDI_PLATFORM=windows -DQBDI_ARCH=X86_64 -DQBDI_EXAMPLES=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`